### PR TITLE
fix year ambiguity in Chinese after core.clj change

### DIFF
--- a/resources/picsou/rules/cn.duration.clj
+++ b/resources/picsou/rules/cn.duration.clj
@@ -38,7 +38,7 @@
    :in-width (months 1)}
   
   "year (unit-of-duration)"
-  #"年"
+  #"年(?=[前|后|後])"
   {:dim :unit-of-duration
    :grain years
    :in-width (years 1)}


### PR DESCRIPTION
Now all test cases are passing by applying this commit on current HEAD of wit-ai/picsou master

```
picsou.core=> (load!)
Jul 09, 2014 12:56:40 AM clojure.tools.logging$eval615$fn__619 invoke
INFO: Loading module  :fr$core
Jul 09, 2014 12:56:41 AM clojure.tools.logging$eval615$fn__619 invoke
INFO: Loading module  :en$core
Jul 09, 2014 12:56:42 AM clojure.tools.logging$eval615$fn__619 invoke
INFO: Loading module  :es$core
Jul 09, 2014 12:56:43 AM clojure.tools.logging$eval615$fn__619 invoke
INFO: Loading module  :cn$core
nil
picsou.core=> (run)
370 examples, 0 failed.
271 examples, 0 failed.
296 examples, 0 failed.
282 examples, 0 failed.
Results :
:cn$core: 370 examples, 0 failed.
:es$core: 271 examples, 0 failed.
:en$core: 296 examples, 0 failed.
:fr$core: 282 examples, 0 failed.
Global Failed count:  0
nil
```
