### PR TITLE
Added 'in' to work with cycles and nth

### DIFF
--- a/resources/duckling/corpus/en.time.clj
+++ b/resources/duckling/corpus/en.time.clj
@@ -217,6 +217,7 @@
   (datetime 2013 10 7 :grain :week)
 
   "last day of october 2015"
+  "last day in october 2015"
   (datetime 2015 10 31)
 
   "last week of september 2014"
@@ -225,6 +226,7 @@
 
   ;; nth of
   "first tuesday of october"
+  "first tuesday in october"
   (datetime 2013 10 1)
 
   "third tuesday of september 2014"

--- a/resources/duckling/rules/en.time.clj
+++ b/resources/duckling/rules/en.time.clj
@@ -208,7 +208,7 @@
   ;; This, Next, Last
 
   ;; assumed to be strictly in the future:
-  ;; "this Monday" => next week if today in Monday
+  ;; "this Monday" => next week if today is Monday
   "this|next <day-of-week>"
   [#"(?i)this|next" {:form :day-of-week}]
   (pred-nth-not-immediate %2 0)
@@ -241,16 +241,16 @@
   (pred-last-of %2 %4)
 
   "last <cycle> of <time>"
-  [#"(?i)last" (dim :cycle) #"(?i)of" (dim :time)]
+  [#"(?i)last" (dim :cycle) #"(?i)of|in" (dim :time)]
   (cycle-last-of %2 %4)
 
   ; Ordinals
   "nth <time> of <time>"
-  [(dim :ordinal) (dim :time) #"(?i)of" (dim :time)]
+  [(dim :ordinal) (dim :time) #"(?i)of|in" (dim :time)]
   (pred-nth (intersect %4 %2) (dec (:value %1)))
 
   "nth <time> of <time>"
-  [#"(?i)the" (dim :ordinal) (dim :time) #"(?i)of" (dim :time)]
+  [#"(?i)the" (dim :ordinal) (dim :time) #"(?i)of|in" (dim :time)]
   (pred-nth (intersect %5 %3) (dec (:value %2)))
 
   "nth <time> after <time>"


### PR DESCRIPTION
With this change, duckling also parses "first Thursday in January". 

Even in the code, there is:
```clojure
"labor day" ;first Monday in September
```
Which wouldn't be parsed by duckling.