### PR TITLE
Merge in recent PRs

### DIFF
--- a/resources/duckling/corpus/en.finance.clj
+++ b/resources/duckling/corpus/en.finance.clj
@@ -40,6 +40,21 @@
 "EUR29.99"
 (money 29.99 "EUR")
 
+;Indian Currency
+"Rs. 20"
+"Rs 20"
+"20 Rupees"
+"20Rs"
+"Rs20"
+(money 20 "INR")
+
+"20 Rupees 43"
+"twenty rupees 43"
+(money 20.43 "INR")
+
+"INR33"
+(money 33 "INR")
+
 "3 bucks"
 (money 3) ; unknown unit
 

--- a/resources/duckling/corpus/en.time.clj
+++ b/resources/duckling/corpus/en.time.clj
@@ -217,6 +217,7 @@
   (datetime 2013 10 7 :grain :week)
 
   "last day of october 2015"
+  "last day in october 2015"
   (datetime 2015 10 31)
 
   "last week of september 2014"
@@ -225,6 +226,7 @@
 
   ;; nth of
   "first tuesday of october"
+  "first tuesday in october"
   (datetime 2013 10 1)
 
   "third tuesday of september 2014"

--- a/resources/duckling/rules/en.finance.clj
+++ b/resources/duckling/rules/en.finance.clj
@@ -53,6 +53,12 @@
 {:dim :unit
  :unit "cent"}
 
+;Indian Currency
+"INR"
+#"(?i)INR|Rs(. )?|(R|r)upees?"
+{:dim :unit
+ :unit "INR"}
+
 "unnamed currency"
 #"(?i)(buck|balle|pouloute)s?"
 {:dim :unit}

--- a/resources/duckling/rules/en.time.clj
+++ b/resources/duckling/rules/en.time.clj
@@ -208,7 +208,7 @@
   ;; This, Next, Last
 
   ;; assumed to be strictly in the future:
-  ;; "this Monday" => next week if today in Monday
+  ;; "this Monday" => next week if today is Monday
   "this|next <day-of-week>"
   [#"(?i)this|next" {:form :day-of-week}]
   (pred-nth-not-immediate %2 0)
@@ -241,16 +241,16 @@
   (pred-last-of %2 %4)
 
   "last <cycle> of <time>"
-  [#"(?i)last" (dim :cycle) #"(?i)of" (dim :time)]
+  [#"(?i)last" (dim :cycle) #"(?i)of|in" (dim :time)]
   (cycle-last-of %2 %4)
 
   ; Ordinals
   "nth <time> of <time>"
-  [(dim :ordinal) (dim :time) #"(?i)of" (dim :time)]
+  [(dim :ordinal) (dim :time) #"(?i)of|in" (dim :time)]
   (pred-nth (intersect %4 %2) (dec (:value %1)))
 
   "nth <time> of <time>"
-  [#"(?i)the" (dim :ordinal) (dim :time) #"(?i)of" (dim :time)]
+  [#"(?i)the" (dim :ordinal) (dim :time) #"(?i)of|in" (dim :time)]
   (pred-nth (intersect %5 %3) (dec (:value %2)))
 
   "nth <time> after <time>"

--- a/resources/duckling/rules/en.time.clj
+++ b/resources/duckling/rules/en.time.clj
@@ -221,7 +221,7 @@
   (pred-nth %2 0)
 
   "next <time>"
-  [#"(?i)next" (dim :time)]
+  [#"(?i)next" (dim :time #(not (:latent %)))]
   (pred-nth-not-immediate %2 0)
 
   "last <time>"


### PR DESCRIPTION
Add INR support
Support "in" in "Second tuesday in October"
In en.tim, make next only take non-latent times so it won't parse "next <integer>" as the year described by integer