### PR TITLE
Fix matching of day 0 and month 0

### DIFF
--- a/resources/duckling/rules/en.time.clj
+++ b/resources/duckling/rules/en.time.clj
@@ -421,15 +421,15 @@
   ; Formatted dates and times
 
   "mm/dd/yyyy"
-  #"(0?\d|10|11|12)[/-](30|31|[012]?\d)[-/](\d{2,4})"
+  #"(0?[1-9](?!\d)|10|11|12)[/-](30|31|0?[1-9](?!\d)|[12]\d)[-/](\d{2,4})"
   (parse-dmy (second (:groups %1)) (first (:groups %1)) (nth (:groups %1) 2) true)
 
   "yyyy-mm-dd"
-  #"(\d{2,4})-(0?\d|10|11|12)-(30|31|[012]?\d)"
+  #"(\d{2,4})-(0?[1-9](?!\d)|10|11|12)-(30|31|0?[1-9](?!\d)|[12]\d)"
   (parse-dmy (nth (:groups %1) 2) (second (:groups %1)) (first (:groups %1)) true)
 
   "mm/dd"
-  #"(0?\d|10|11|12)/(30|31|[012]?\d)"
+  #"(0?[1-9](?!\d)|10|11|12)/(30|31|0?[1-9](?!\d)|[12]\d)"
   (parse-dmy (second (:groups %1)) (first (:groups %1)) nil true)
 
 
@@ -557,7 +557,7 @@
   ; Intervals
 
   "<month> dd-dd (interval)"
-  [{:form :month} #"([012]?\d|30|31)" #"\-|to|th?ru|through|until" #"([012]?\d|30|31)"]
+  [{:form :month} #"(0?[1-9](?!\d)|[12]\d|30|31)" #"\-|to|th?ru|through|until" #"(0?[1-9](?!\d)|[12]\d|30|31)"]
   (interval (intersect %1 (day-of-month (Integer/parseInt (-> %2 :groups first))))
             (intersect %1 (day-of-month (Integer/parseInt (-> %4 :groups first))))
             true)


### PR DESCRIPTION
Currently something like "0/1" is matched as a month/day, which causes a :pre assert to fail later on.