### PR TITLE
Extend safe-max for compose in time.pred to allow for more distant intersections

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wit/duckling "0.3.8"
+(defproject wit/duckling "0.3.9"
   :description "Date & Number parser"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/duckling/time/pred.clj
+++ b/src/duckling/time/pred.clj
@@ -31,7 +31,7 @@
 
 ; Limit the space search beam
 
-(def safe-max 100)
+(def safe-max 183) ; 366 (days in a leap year) if we take safe-max forward and backward
 (def safe-max-interval 12)
 
 ;; Debug utlity


### PR DESCRIPTION
Patches issue #41. Outcome for "Friday April 24th from 8pm to 2am" was incorrect because "Friday April 24th" (or any <day of week> <day of month> intersection more than 100 weeks before or after the context reference time) was not resolving to a value.