### PR TITLE
compute candidate prob only once

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wit/duckling "0.3.16"
+(defproject wit/duckling "0.3.17"
   :description "Date & Number parser"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -11,8 +11,7 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [clj-time "0.8.0"]
                  [prismatic/plumbing "0.3.3"]]
-  :deploy-repositories [["private" {:url "s3p://wit-ai/releases" :username :env :passphrase :env :sign-releases false}]
-                        ["clojars" {:creds :gpg}]]
+  :deploy-repositories [["clojars" {:creds :gpg}]]
   :profiles {:dev {:dependencies [[org.clojure/tools.trace "0.7.6"]
                                   [midje "1.6.3"]
                                   [cheshire "5.3.1"]]}

--- a/resources/duckling/rules/en.cycles.clj
+++ b/resources/duckling/rules/en.cycles.clj
@@ -76,7 +76,7 @@
   
   "<cycle> before <time>"
   [(dim :cycle) #"(?i)before" (dim :time)]
-  (cycle-nth-after (:grain %1) -1 %3git)
+  (cycle-nth-after (:grain %1) -1 %3)
 
   "last n <cycle>"
   [#"(?i)last|past" (integer 1 9999) (dim :cycle)]

--- a/test/duckling/core_test.clj
+++ b/test/duckling/core_test.clj
@@ -25,7 +25,7 @@
 
 (deftest select-winners-test
   (is (= '({:value "ok", :pred 9} {:value "ok", :pred 6})
-         (select-winners' compare-fn resolve-fn tokens))))
+         (select-winners' compare-fn (constantly nil) resolve-fn tokens))))
 
 
 ; returns :ok if the corpus runs well, or a string with list of failures otherwise


### PR DESCRIPTION
This prevents having `learn/route-prob` being called many times for each sample