### PR TITLE
fix bug causing floating-point number tokens to be treated as integers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wit/duckling "0.3.17"
+(defproject wit/duckling "0.3.18"
   :description "Date & Number parser"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/duckling/time/prod.clj
+++ b/src/duckling/time/prod.clj
@@ -205,7 +205,7 @@
   [n1 n2]
   (if (> (Math/pow 10 (:grain n1)) (:value n2))
     {:dim :number
-     :integer true
+     :integer (and (:integer n1) (:integer n2))
      :value (+ (:value n1) (:value n2))}
     {:invalid true})) ; TODO return nil and manage "abortion" in engine
 


### PR DESCRIPTION
This is semantically false, and also causes exceptions (e.g. when feeding those numbers to a `DateTime` constructor.)