### PR TITLE
fixing named-month (setembro/september) regex

### DIFF
--- a/resources/languages/pt/rules/time.clj
+++ b/resources/languages/pt/rules/time.clj
@@ -87,7 +87,7 @@
   (month 8)
 
   "named-month"
-  #"(?i)setembro|set?\.?"
+  #"(?i)setembro|set\.?"
   (month 9)
 
   "named-month"


### PR DESCRIPTION
the rule had an extra '?'