### PR TITLE
Extend new language : Indonesian but need more fix

### DIFF
--- a/resources/languages/id/corpus/finance.clj
+++ b/resources/languages/id/corpus/finance.clj
@@ -1,0 +1,64 @@
+(
+
+{}
+
+"$10"
+"10$"
+"sepuluh dolar"
+(money 10 "$")
+
+;"under $15"
+;"no more than 15$"
+;"no greater than 15$"
+;"less than fifteen dollars"
+;(money 15 "$" "<")
+
+"$10.000"
+"10K$"
+"$10k"
+(money 10000 "$")
+
+"USD1,23"
+(money 1.23 "USD")
+
+"2 dolar"
+"dua dolar"
+(money 2 "$")
+
+"20€"
+"20 euros"
+"20 Euro"
+"20 Euros"
+"EUR 20"
+(money 20 "EUR")
+
+"EUR29,99"
+(money 29.99 "EUR")
+
+;Indian Currency
+"Rp. 20,00"
+"Rp 20"
+"20 Rupiah"
+"20Rp"
+"Rp20"
+(money 20 "IDR")
+
+"IDR33"
+"IDR 35.000"
+(money 33 "IDR")
+
+"£9"
+"sembilan pound"
+(money 9 "£")
+
+"GBP3,01"
+"GBP 3,01"
+(money 3.01 "GBP")
+
+)
+
+;around $200
+;between $200 and $300
+;around 200-500 dollars
+;up to 1000
+;~50-100

--- a/resources/languages/id/corpus/finance.clj
+++ b/resources/languages/id/corpus/finance.clj
@@ -35,17 +35,19 @@
 "EUR29,99"
 (money 29.99 "EUR")
 
-;Indian Currency
-"Rp. 20,00"
+;Indonesian Currency
+"Rp. 315,00"
+(money 315.0 "IDR")
+
 "Rp 20"
 "20 Rupiah"
 "20Rp"
 "Rp20"
 (money 20 "IDR")
 
-"IDR33"
-"IDR 35.000"
-(money 33 "IDR")
+"IDR33000"
+"IDR 33.000"
+(money 33000 "IDR")
 
 "£9"
 "sembilan pound"

--- a/resources/languages/id/corpus/numbers.clj
+++ b/resources/languages/id/corpus/numbers.clj
@@ -1,0 +1,99 @@
+(
+  ; Context map
+  {}
+
+  "0"
+  "nol"
+  "kosong"
+  (number 0)
+
+  "1"
+  "satu"
+  (number 1)
+
+  "2"
+  "dua"
+  (number 2)
+
+  "10"
+  "sepuluh"
+  (number 10)
+  
+  "33"
+  "tiga puluh tiga"
+  "0033"
+  (number 33)
+  
+  "100"
+  "seratus"
+  (number 100)
+
+  "17"
+  "tujuh belas"
+  (number 17)
+
+  "28"
+  "dua puluh delapan"
+  (number 28)
+
+  "1,1"
+  "1,10"
+  "01,10"
+  (number 1.1)
+
+  "0,77"
+  ",77"
+  (number 0.77)
+  
+  "100.000"
+  "100000"
+  "100K"
+  "100k"
+  (number 100000)
+  
+  "3M"
+  "3000K"
+  "3000000"
+  "3.000.000"
+  (number 3000000)
+  
+  "1.200.000"
+  "1200000"
+  "1,2M"
+  "1200K"
+  ",0012G"
+  (number 1200000)
+
+  "- 1.200.000"
+  "-1200000"
+  "minus 1.200.000"
+  "negatif 1200000"
+  "-1,2M"
+  "-1200K"
+  "-,0012G"
+  "-0,0012G"
+  (number -1200000)
+
+  "5 ribu"
+  "lima ribu"
+  (number 5000)
+
+  "seratus dua puluh dua"
+  (number 122)
+
+  "dua ratus ribu"
+  (number 200000)
+
+  "sepuluh ribu sebelas"
+  (number 10011)
+
+  "tujuh ratus dua puluh satu ribu dua belas"
+  (number 721012)
+
+  "tiga puluh satu juta dua ratus lima puluh enam ribu tujuh ratus dua puluh satu"
+  (number 31256721)
+
+  "ke-4"
+  "keempat"
+  (ordinal 4)
+)

--- a/resources/languages/id/rules/finance.clj
+++ b/resources/languages/id/rules/finance.clj
@@ -53,7 +53,7 @@
  :unit "INR"}
 
 ;Indonesian Currency
-"INR"
+"IDR"
 #"(?i)IDR|Rp(. )?|(R|r)upiah"
 {:dim :unit
  :unit "IDR"}

--- a/resources/languages/id/rules/finance.clj
+++ b/resources/languages/id/rules/finance.clj
@@ -1,0 +1,84 @@
+(
+
+"intersect" ;
+[(dim :amount-of-money) (dim :number)]
+(compose-money %1 %2) 
+
+; #(not (:number-prefixed %)
+
+"$"
+#"\$|dolar?"
+{:dim :unit
+ :unit "$"} ; ambiguous
+ 
+"€"
+#"(?i)€|([e€]uro?s?)"
+{:dim :unit
+ :unit "EUR"} ; not ambiguous
+
+"£"
+#"(?i)£|pound(sterling)?"
+{:dim :unit
+ :unit "£"}
+
+"USD"
+#"(?i)US[D\$]"
+{:dim :unit
+ :unit "USD"}
+
+"SGD"
+#"(?i)SG[D\$]"
+{:dim :unit
+ :unit "SGD"}
+
+"GBP"
+#"(?i)GBP"
+{:dim :unit
+ :unit "GBP"}
+
+"JPY"
+#"(?i)JPY|¥(. )?|(Y|y)en"
+{:dim :unit
+ :unit "JPY"}
+
+"PTS"
+#"(?i)pta?s?"
+{:dim :unit
+ :unit "PTS"}
+
+;Indian Currency
+"INR"
+#"(?i)INR|Rs(. )?|(R|r)upee"
+{:dim :unit
+ :unit "INR"}
+
+;Indonesian Currency
+"INR"
+#"(?i)IDR|Rp(. )?|(R|r)upiah"
+{:dim :unit
+ :unit "IDR"}
+
+"<unit> <amount>"
+[(dim :unit) (dim :number)]
+{:dim :amount-of-money
+ :value (:value %2)
+ :unit (:unit %1)
+ :fields {(:unit %1) (:value %2)}}
+
+"<amount> <unit>"
+[(dim :number) (dim :unit)]
+{:dim :amount-of-money
+ :value (:value %1)
+ :unit (:unit %2)
+ :fields {(:unit %1) (:value %2)}}
+
+;precision for "about $15"
+"about <amount-of-money>"
+[#"(?i)about|approx(\.|imately)?|close to|near( to)?|around|almost" (dim :amount-of-money)]
+(assoc %2 :precision "approximate")
+
+"exactly <amount-of-money>"
+[#"(?i)exactly|precisely" (dim :amount-of-money)]
+(assoc %2 :precision "exact")
+
+)

--- a/resources/languages/id/rules/numbers.clj
+++ b/resources/languages/id/rules/numbers.clj
@@ -1,0 +1,163 @@
+(
+  "intersect"
+  [(dim :number :grain #(> (:grain %) 1)) (dim :number)] ; grain 1 are taken care of by specific rule
+  (compose-numbers %1 %2)
+
+ ;;
+ ;; Integers
+ ;;
+
+  "integer (0..9 11)"
+  #"(?i)(kosong|nol|satu|dua|tiga|empat|lima|enam|tujuh|delapan|sembilan|sebelas)"
+  {:dim :number
+   :integer true
+   :value (get {"kosong" 0 "nol" 0 "satu" 1 "dua" 2 "tiga" 3 "empat" 4 "lima" 5 "enam" 6 "tujuh" 7 "delapan" 8 "sembilan" 9 "sebelas" 11}
+              (-> %1 :groups first clojure.string/lower-case))}
+
+  "ten"
+  #"(?i)(se)?puluh"
+  {:dim :number :integer true :value 10 :grain 1}
+
+  "teen"
+  [(integer 2 9) #"belas"]
+  {:dim :number
+   :integer true
+   :value (+ (:value %1) 10)}
+
+  "dozen"
+  #"(?i)(se)?lusin"
+  {:dim :number :integer true :value 12 :grain 1 :grouping true} ;;restrict composition and prevent "2 12"
+
+  "hundred"
+  #"(?i)(se)?ratus"
+  {:dim :number :integer true :value 100 :grain 2}
+
+  "thousand"
+  #"(?i)(se)?ribu"
+  {:dim :number :integer true :value 1000 :grain 3}
+
+  "million"
+  #"(?i)(se)?juta"
+  {:dim :number :integer true :value 1000000 :grain 6}
+
+  "some/few/couple" ; TODO set assumption
+  #"beberapa"
+  {:dim :number :integer true :precision :approximate :value 3}
+
+  "integer 20..90"
+  [(integer 2 9) (integer 10 10)]
+  {:dim :number
+   :integer true
+   :value (* (:value %1) (:value %2))
+   :grain (:grain %2)}
+
+  "integer 21..99"
+  [(integer 10 90 #(#{20 30 40 50 60 70 80 90} (:value %))) (integer 1 9)]
+  {:dim :number
+   :integer true
+   :value (+ (:value %1) (:value %2))}
+
+  "integer (numeric)"
+  #"(\d{1,18})"
+  {:dim :number
+   :integer true
+   :value (Long/parseLong (first (:groups %1)))}
+
+  "integer with thousands separator ."
+  #"(\d{1,3}(\.\d\d\d){1,5})"
+  {:dim :number
+   :integer true
+   :value (-> (:groups %1)
+            first
+            (clojure.string/replace #"\." "")
+            Long/parseLong)}
+
+  "number hundreds"
+  [(integer 2 99) (integer 100 100)]
+  {:dim :number
+   :integer true
+   :value (* (:value %1) (:value %2))
+   :grain (:grain %2)}
+
+  "number thousands"
+  [(integer 2 999) (integer 1000 1000)]
+  {:dim :number
+   :integer true
+   :value (* (:value %1) (:value %2))
+   :grain (:grain %2)}
+
+  "number millions"
+  [(integer 2 99) (integer 1000000 1000000)]
+  {:dim :number
+   :integer true
+   :value (* (:value %1) (:value %2))
+   :grain (:grain %2)}
+
+  ;;
+  ;; Decimals
+  ;;
+
+  "decimal number"
+  #"(\d*,\d+)"
+  {:dim :number
+   :value (-> (:groups %1)
+            first
+            (clojure.string/replace #"," ".")
+            Double/parseDouble)}
+
+  "number comma number"
+  [(dim :number #(not (:number-prefixed %))) #"(?i)koma" (dim :number #(not (:number-suffixed %)))]
+  {:dim :number
+   :value (+ (* 0.1 (:value %3)) (:value %1))}
+
+
+  "decimal with thousands separator"
+  #"(\d+(\.\d\d\d)+,\d+)"
+  {:dim :number
+   :value (-> (:groups %1)
+            first
+            (clojure.string/replace #"\." "")
+            Double/parseDouble)}
+
+  ;; negative number
+  "numbers prefix with -, negative or minus"
+  [#"(?i)-|minus\s?|negatif\s?" (dim :number #(not (:number-prefixed %)))]
+  (let [multiplier -1
+        value      (* (:value %2) multiplier)
+        int?       (zero? (mod value 1)) ; often true, but we could have 1.1111K
+        value      (if int? (long value) value)] ; cleaner if we have the right type
+    (assoc %2 :value value
+              :integer int?
+              :number-prefixed true)) ; prevent "- -3km" to be 3 billions
+
+
+  ;; suffixes
+
+  ; note that we check for a space-like char after the M, K or G
+  "numbers suffixes (K, M, G)"
+  [(dim :number #(not (:number-suffixed %))) #"(?i)([kmg])(?=[\W\$€]|$)"]
+  (let [multiplier (get {"k" 1000 "m" 1000000 "g" 1000000000}
+                        (-> %2 :groups first clojure.string/lower-case))
+        value      (* (:value %1) multiplier)
+        int?       (zero? (mod value 1)) ; often true, but we could have 1.1111K
+        value      (if int? (long value) value)] ; cleaner if we have the right type
+    (assoc %1 :value value
+              :integer int?
+              :number-suffixed true)) ; prevent "3km" to be 3 billions
+
+  ;;
+  ;; Ordinal numbers
+  ;;
+
+  "ordinals"
+  #"(?i)(pertama|kedua|ketiga|keempat|kelima|keenam|ketujuh|kedelapan|kesembilan|kesepuluh)"
+  {:dim :ordinal 
+   :value (get {"pertama" 1 "kedua" 2 "ketiga" 3 "keempat" 4 "kelima" 5 "keenam" 6 "ketujuh" 7 "kedelapan" 8 "kesembilan" 9 "kesepuluh" 10}
+              (-> %1 :groups first clojure.string/lower-case))}
+
+  "ordinals (digits)"
+  #"ke-0*(\d+)"
+  {:dim :ordinal
+   :value (read-string (first (:groups %1)))}  ; read-string not the safest
+
+)


### PR DESCRIPTION
Add Indonesian numeric system and currency. Specifically, there are difference usage of comma and dot between Indonesian and English one (comma for decimal and dot for thousand separator). Is this okay?

Todo :
- more numbers
- generalize ordinal number