### PR TITLE
fixed typo

### DIFF
--- a/resources/languages/de/rules/time.clj
+++ b/resources/languages/de/rules/time.clj
@@ -94,7 +94,7 @@
   (month 9)
 
   "named-month"
-  #"(?i)oktober|oct\.?"
+  #"(?i)oktober|okt\.?"
   (month 10)
 
   "named-month"


### PR DESCRIPTION
abbreviation for October in German is okt (not oct)