### PR TITLE
Do not print to stderr

### DIFF
--- a/src/duckling/engine.clj
+++ b/src/duckling/engine.clj
@@ -6,6 +6,7 @@
   3. tokens containing final info are produced using their production rules"
   (:use [clojure.tools.logging])
   (:require [clojure.set :as sets]
+            [clojure.stacktrace]
             [duckling.time.prod]
             [duckling.time.api :as time]
             [duckling.util :as util]))

--- a/src/duckling/engine.clj
+++ b/src/duckling/engine.clj
@@ -134,7 +134,8 @@
                                     (subs sentence pos end)
                                     (:name rule)
                                     sentence
-                                    e (.printStackTrace e))
+                                    e
+                                    (with-out-str (clojure.stacktrace/print-stack-trace e)))
                         {:exception e}))))))
 
 (defn- never-produced?
@@ -163,9 +164,13 @@
                       (conj route token)
                       results)))
                 (catch Exception e
-                  (.printStackTrace e)
-                  (prn stash)
-                  (throw (ex-info "Exception @match" {:exception e}))))))]
+                  ;; (.printStackTrace e) - probably use logging/debug and turn logging output
+                  ;; (prn stash)
+                  (throw (ex-info (format "Exception @match stack=%s stash=%s"
+                                          (with-out-str (clojure.stacktrace/print-stack-trace e))
+                                          (with-out-str (pr stash)))
+                                  {:exception e}))
+                  ))))]
     (match-recur pattern true stash 0 [] [])))
 
 (defn- pass-once


### PR DESCRIPTION
Fix two issues with caught exceptions in production

1. `.printStackTrace` does **not** return the stack trace but prints it to
`stderr`
2. generally it is annoying in production if logs are cluttered with
java/clojure stack traces; rather, as was probably indented, pass the
stack trace and related information upwards in the exception