### PR TITLE
various fixes in FR and EN :

### DIFF
--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -136,6 +136,7 @@
   (datetime 2013 2 4 :grain :week)
 
   "next week"
+  "the following week"
   (datetime 2013 2 18 :grain :week)
 
   "last month"
@@ -706,4 +707,8 @@
   "at 12am"
   "at midnight"
   (datetime 2013 2 13 0)
+
+  "March"
+  "in March"
+  (datetime 2013 3)
 )

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -59,7 +59,7 @@
   (cycle-nth (:grain %2) -1)
 
   "next <cycle>"
-  [#"(?i)next" (dim :cycle)]
+  [#"(?i)next|the following" (dim :cycle)]
   (cycle-nth (:grain %2) 1)
   
   "the <cycle> after <time>"

--- a/resources/languages/en/rules/time.clj
+++ b/resources/languages/en/rules/time.clj
@@ -21,10 +21,13 @@
   [#"(?i)on" (dim :time)]
   %2 ; does NOT dissoc latent
 
-  "on a named-day" ; on a sunday
+  "on a <named-day>" ; on a sunday
   [#"(?i)on a" {:form :day-of-week}]
   %2 ; does NOT dissoc latent
 
+  "in <named-month>" ; in September
+  [#"(?i)in" {:form :month}]
+  %2 ; does NOT dissoc latent
 
   ;;;;;;;;;;;;;;;;;;;
   ;; Named things

--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -120,6 +120,7 @@
   "le 16 à 6h du soir"
   "le 16 vers 6h du soir"
   "le 16 vers 6h dans la soirée"
+  "samedi 16 à 18h"
   (datetime 2013 2 16 18 :day 16 :hour 18)
 
   "17 février"
@@ -167,7 +168,7 @@
   "le 24 12 2014"
   "le 24 12 14"
   (datetime 2014 12 24 :day 24 :month 12 :year 2014)
-  
+
   "31/10/1974"
   "31/10/74" ; smart two-digit year resolution
   (datetime 1974 10 31 :day 31 :month 10 :year 1974)
@@ -244,6 +245,8 @@
   (datetime 2013 2 4 :grain :week)
   
   "la semaine prochaine"
+  "la semaine suivante"
+  "la semaine qui suit"
   (datetime 2013 2 18 :grain :week)
   
   "le mois dernier"
@@ -266,15 +269,23 @@
   (datetime 2013 2 10 :day-of-week 7)
 
   "3eme jour d'octobre"
+  "le 3eme jour d'octobre"
   (datetime 2013 10 3)
   
   "premiere semaine d'octobre 2014"
+  "la premiere semaine d'octobre 2014"
   (datetime 2014 10 6 :grain :week)
   
+  "la semaine du 6 octobre"
+  "la semaine du 7 octobre"
+  (datetime 2013 10 7 :grain :week)
+
   "dernier jour d'octobre 2015"
+  "le dernier jour d'octobre 2015"
   (datetime 2015 10 31)
   
   "dernière semaine de septembre 2014"
+  "la dernière semaine de septembre 2014"
   (datetime 2014 9 22 :grain :week)
 
   ;; Hours
@@ -472,11 +483,12 @@
 
   "demain soir"
   "mercredi soir"
+  "mercredi en soirée"
   (datetime-interval [2013 2 13 18] [2013 2 14 00])
   
   "hier soir"
   (datetime-interval [2013 2 11 18] [2013 2 12 00])
-    
+  
   "ce week-end"
   (datetime-interval [2013 2 15 18] [2013 2 18 00])
 
@@ -484,6 +496,7 @@
   (datetime-interval [2013 2 18 4] [2013 2 18 12])
 
   "lundi après-midi"
+  "lundi dans l'après-midi"
   (datetime-interval [2013 2 18 12] [2013 2 18 19])
 
   "lundi fin d'après-midi"
@@ -574,23 +587,30 @@
 
   "à partir du 8"
   "à partir du 8 mars"
-  (datetime 2013 3 8)
+  (datetime 2013 3 8 :direction :after)
 
   "à partir de 9h30 jeudi"
   "jeudi après 9h30"
-  (datetime 2013 2 14 9 30) ; FIXME should be :
+  (datetime 2013 2 14 9 30 :direction :after) ; FIXME should be :
   ;(datetime-interval [2013 2 14 9 30] [2013 2 15])
 
   "après 16h le 1er novembre"
-  (datetime 2013 11 1 16) ; FIXME should be :
+  (datetime 2013 11 1 16 :direction :after) ; FIXME should be :
   ;(datetime-interval [2013 11 1 16] [2013 11 1 24])
 
+  "avant 16h"
+  "n'importe quand avant 16h"
+  (datetime 2013 2 12 16 :direction :before)
+  
+  "demain jusqu'à 16h"
+  (datetime-interval [2013 2 13 0] [2013 2 13 17])
+  
   "le 20 à partir de 10h"
-  (datetime 2013 2 20 10) ; FIXME should be :
+  (datetime 2013 2 20 10 :direction :after) ; FIXME should be :
   ;(datetime-interval [2013 2 20 10] [2013 2 21])
 
   "vendredi à partir de midi"
-  (datetime 2013 2 15 12) ; FIXME should be :
+  (datetime 2013 2 15 12 :direction :after) ; FIXME should be :
   ;(datetime-interval [2013 2 15 12] [2013 2 16])
 
   "le 20 jusqu'à 18h"
@@ -637,7 +657,9 @@
   (datetime-interval [2013 4 1] [2013 4 6])
 
   "mi-décembre"
-  "mi décembre"
   (datetime-interval [2013 12 10] [2013 12 20])
   
+  "mars"
+  "en mars"
+  (datetime 2013 3)
 )

--- a/resources/languages/fr/rules/cycles.clj
+++ b/resources/languages/fr/rules/cycles.clj
@@ -45,7 +45,7 @@
   (cycle-nth (:grain %2) -1)
 
   "le <cycle> prochain|suivant|d'après"
-  [#"(?i)l[ae']? ?" (dim :cycle) #"(?i)prochaine?|suivante?|d'apr[eèé]s"]
+  [#"(?i)l[ae']? ?" (dim :cycle) #"(?i)prochaine?|suivante?|qui suit|d'apr[eèé]s"]
   (cycle-nth (:grain %2) 1)
   
   "le <cycle> après|suivant <time>"
@@ -73,11 +73,15 @@
   (cycle-n-not-immediate (:grain %2) (:value %1))
 
   "<ordinal> <cycle> de <time>"
-  [(dim :ordinal) (dim :cycle) #"(?i)d['e]|en" (dim :time)]
+  [(dim :ordinal) (dim :cycle) #"(?i)d['eu]|en" (dim :time)]
   (cycle-nth-after-not-immediate (:grain %2) (dec (:value %1)) %4)
   
   "le <ordinal> <cycle> de <time>"
-  [#"(?i)le" (dim :ordinal) (dim :cycle) #"(?i)d['e]|en" (dim :time)]
-  (cycle-nth-after (:grain %3) (dec (:value %2)) %5)
+  [#"(?i)l[ea]" (dim :ordinal) (dim :cycle) #"(?i)d['eu]|en" (dim :time)]
+  (cycle-nth-after-not-immediate (:grain %3) (dec (:value %2)) %5)
+
+  "le <cycle> de <time>"
+  [#"(?i)l[ea]" (dim :cycle) #"(?i)d['eu]|en" (dim :time)]
+  (cycle-nth-after-not-immediate (:grain %2) 0 %4)
 
 )


### PR DESCRIPTION
EN:
- IN september (in <named-month>)
- the following week (the following <cycle>)

FR:
- "L'après-midi" (the afternoon) should NOT be latent
- lundi EN soirée (monday evening)
- la semaine QUI SUIT (the following week)
- EN septembre (in september)
- LA dernière semaine d'août (the last week of August)
- lundi dans l'après-midi (monday in the afternoon)
- fix : samedi 12 à 18h (is not 'samedi de 12h à 18h')
- fix: 'avant 16h' should be a one-sided interval