### PR TITLE
Add en semaine for french version (during the week)

### DIFF
--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -254,25 +254,25 @@
 
   "la semaine dernière"
   (datetime 2013 2 4 :grain :week)
-  
+
   "la semaine prochaine"
   "la semaine suivante"
   "la semaine qui suit"
   (datetime 2013 2 18 :grain :week)
-  
+
   "le mois dernier"
   (datetime 2013 1)
 
   "le mois prochain"
   "le mois suivant"
   (datetime 2013 3)
-  
+
   "l'année dernière"
   (datetime 2012)
-  
+
   "cette année"
   (datetime 2013)
-  
+
   "l'année prochaine"
   (datetime 2014)
 
@@ -283,11 +283,11 @@
   "3eme jour d'octobre"
   "le 3eme jour d'octobre"
   (datetime 2013 10 3)
-  
+
   "premiere semaine d'octobre 2014"
   "la premiere semaine d'octobre 2014"
   (datetime 2014 10 6 :grain :week)
-  
+
   "la semaine du 6 octobre"
   "la semaine du 7 octobre"
   (datetime 2013 10 7 :grain :week)
@@ -295,7 +295,7 @@
   "dernier jour d'octobre 2015"
   "le dernier jour d'octobre 2015"
   (datetime 2015 10 31)
-  
+
   "dernière semaine de septembre 2014"
   "la dernière semaine de septembre 2014"
   (datetime 2014 9 22 :grain :week)
@@ -363,7 +363,7 @@
   "onze heures trois quarts"
   "aujourd'hui à 11h45"
   (datetime 2013 2 12 11 45 :hour 11 :minute 45)
-  
+
   "mercredi à 11h"
   (datetime 2013 2 13 11 :hour 11 :day-of-week 3)
 
@@ -384,28 +384,28 @@
   ;; Involving periods   ; look for grain-after-shift
   "dans une seconde"
   (datetime 2013 2 12 4 30 1)
-  
+
   "dans une minute"
   "dans 1 min"
   (datetime 2013 2 12 4 31 0)
-  
+
   "dans 2 minutes"
   "dans deux min"
   (datetime 2013 2 12 4 32 0)
-  
+
   "dans 60 minutes"
   (datetime 2013 2 12 5 30 0)
-  
+
   "dans une heure"
   (datetime 2013 2 12 5 30)
 
   "il y a deux heures"
   (datetime 2013 2 12 2 30)
-  
+
   "dans 24 heures"
   "dans vingt quatre heures"
   (datetime 2013 2 13 4 30)
-  
+
   "dans un jour"
   (datetime 2013 2 13 4)
 
@@ -417,24 +417,24 @@
 
   "dans 7 jours"
   (datetime 2013 2 19 4)
-  
+
   "dans 1 semaine"
   "dans une semaine"
   (datetime 2013 2 19)
-  
+
   "il y a trois semaines"
   (datetime 2013 1 22)
-  
+
   "dans deux mois"
   (datetime 2013 4 12)
-  
+
   "il y a trois mois"
   (datetime 2012 11 12)
 
   "dans une année"
   "dans 1 an"
   (datetime 2014 2)
-  
+
   "il y a deux ans"
   (datetime 2011 2)
 
@@ -446,7 +446,7 @@
   "cet hiver"
   (datetime-interval [2012 12 21] [2013 3 21])
 
-  ; FR holidays 
+  ; FR holidays
 
   "Noel"
   "noël"
@@ -472,7 +472,7 @@
   (datetime 2013 05 1)
 
   ; Part of day (morning, afternoon...)
-  
+
   "cet après-midi"
   "l'après-midi"
   (datetime-interval [2013 2 12 12] [2013 2 12 19])
@@ -482,6 +482,18 @@
 
   "en fin de matinée"
   (datetime-interval [2013 2 12 10] [2013 2 12 12])
+
+  "après déjeuner"
+  (datetime-interval [2013 2 12 13] [2013 2 12 17])
+
+  "avant déjeuner"
+  (datetime-interval [2013 2 12 10] [2013 2 12 12])
+
+  "pendant le déjeuner"
+  (datetime-interval [2013 2 12 12] [2013 2 12 14])
+
+  "après le travail"
+  (datetime-interval [2013 2 12 17] [2013 2 12 21])
 
   "dès le matin"
   "dès la matinée"
@@ -506,11 +518,11 @@
   "mercredi soir"
   "mercredi en soirée"
   (datetime-interval [2013 2 13 18] [2013 2 14 00])
-  
+
   "hier soir"
   "la veille au soir"
   (datetime-interval [2013 2 11 18] [2013 2 12 00])
-  
+
   "ce week-end"
   (datetime-interval [2013 2 15 18] [2013 2 18 00])
 
@@ -543,7 +555,7 @@
   "lundi en fin d'après-midi"
   (datetime-interval [2013 2 18 17] [2013 2 18 19])
 
-  "le 15 février dans la matinée" 
+  "le 15 février dans la matinée"
   "matinée du 15 février"
   "le 15 février le matin"
   (datetime-interval [2013 2 15 4] [2013 2 15 12])
@@ -551,13 +563,13 @@
   "8 heures ce soir"
   "8h du soir"
   (datetime 2013 2 12 20)
-  
+
   "3 heures du matin"
   "3h du mat"
   (datetime 2013 2 13 3)
 
  ; Intervals involving cycles
-  
+
   "2 dernières secondes"
   "deux dernieres secondes"
   (datetime-interval [2013 2 12 4 29 58] [2013 2 12 4 30 00])
@@ -602,9 +614,9 @@
   "2 dernieres annees"
   "2 années passées"
   (datetime-interval [2011] [2013])
-  
+
   "3 prochaines années"
-  (datetime-interval [2014] [2017]) 
+  (datetime-interval [2014] [2017])
 
   ; Explicit intervals
 
@@ -666,10 +678,10 @@
   "avant 16h"
   "n'importe quand avant 16h"
   (datetime 2013 2 12 16 :direction :before)
-  
+
   "demain jusqu'à 16h"
   (datetime-interval [2013 2 13 0] [2013 2 13 17])
-  
+
   "le 20 à partir de 10h"
   (datetime 2013 2 20 10 :direction :after) ; FIXME should be :
   ;(datetime-interval [2013 2 20 10] [2013 2 21])
@@ -683,7 +695,7 @@
 
   "14 - 20 sept. 2014"
   (datetime-interval [2014 9 14] [2014 9 21])
-  
+
   ; Alex: need special rule to say that 11h is not ambiguous, because of midi
   ; "ven., 19 septembre, 11h - midi"
   ; (datetime-interval [2014 9 19 11] [2014 9 19 12])
@@ -702,7 +714,7 @@
 
   "jeudi de 9h à 11h"
   (datetime-interval [2013 2 14 9] [2013 2 14 12])
-  
+
   "entre midi et 2"
   (datetime-interval [2013 2 12 12] [2013 2 12 15])
 
@@ -710,10 +722,10 @@
   "de 11h30 à 1h30"
   "de 11h30 jusqu'à 1h30"
   (datetime-interval [2013 2 12 11 30] [2013 2 12 13 31])
-  
+
   "13h30 samedi 21 septembre"
    (datetime 2013 9 21 13 30)
-  
+
   "à seize heures PST"
   (datetime 2013 2 12 16 :hour 16 :timezone "PST")
 
@@ -727,7 +739,7 @@
 
   "mi-décembre"
   (datetime-interval [2013 12 10] [2013 12 20])
-  
+
   "mars"
   "en mars"
   "au mois de mars"

--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -250,6 +250,7 @@
   ;; Cycles
 
   "cette semaine"
+  "en semaine"
   "dans la semaine"
   (datetime 2013 2 11 :grain :week)
 
@@ -385,7 +386,7 @@
   "vendredi 15 à 16h"
   "vendredi quinze à 16h"
   (datetime 2013 2 15 16 :hour 16 :day-of-week 4)
-  
+
 
   ;; Involving periods   ; look for grain-after-shift
   "dans une seconde"
@@ -544,7 +545,7 @@
   ; TODO
   ;"en début de semaine prochaine"
   ;(datetime-interval [2013 2 18] [2013 2 20])
-  
+
   "le premier week-end de septembre"
   (datetime-interval [2013 9 6 18] [2013 9 9 00])
 
@@ -752,14 +753,14 @@
 
   "la première quinzaine d'avril"
   (datetime-interval [2013 4 1] [2013 4 15])
-  
+
   "la deuxième quinzaine d'avril"
   (datetime-interval [2013 4 15] [2013 5 01])
-  
+
   "début avril"
   "début du mois d'avril"
   (datetime-interval [2013 4 1] [2013 4 6])
-  
+
   "mi-décembre"
   (datetime-interval [2013 12 10] [2013 12 20])
 

--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -250,7 +250,6 @@
   ;; Cycles
 
   "cette semaine"
-  "en semaine"
   "dans la semaine"
   (datetime 2013 2 11 :grain :week)
 
@@ -541,6 +540,9 @@
 
   "en fin de semaine"
   (datetime-interval [2013 2 14] [2013 2 18])
+
+  "en semaine"
+  (datetime-interval [2013 2 11] [2013 2 16])
 
   ; TODO
   ;"en début de semaine prochaine"

--- a/resources/languages/fr/rules/time.clj
+++ b/resources/languages/fr/rules/time.clj
@@ -454,8 +454,8 @@
     (interval (day-of-week 4) (day-of-week 7) false)
 
   "en semaine"
-  [#"(?i)(pendant la|cette |en )?semaine"]
-    (cycle-nth :week 0)
+  [#"(?i)(pendant la |en )?semaine"]
+    (interval (day-of-week 1) (day-of-week 5) false)
 
   "season"
   #"(?i)(cet )?été" ;could be smarter and take the exact hour into account... also some years the day can change

--- a/resources/languages/fr/rules/time.clj
+++ b/resources/languages/fr/rules/time.clj
@@ -354,6 +354,28 @@
   #"(?i)fin de matin[ée]e"
   (assoc (interval (hour 10 false) (hour 12 false) false) :form :part-of-day :latent true)
 
+  "au déjeuner"
+  #"(?i)(pendant(le )?|au)? d[eéè]jeuner"
+  (assoc (interval (hour 12 false) (hour 14 false) false) :form :part-of-day :latent true)
+
+  "après le déjeuner"
+  #"(?i)apr[eè]s (le )?d[eéè]jeuner"
+  (assoc (intersect (cycle-nth :day 0)
+                    (interval (hour 13 false) (hour 17 false) false))
+         :form :part-of-day) ; no :latent
+
+  "avant le déjeuner"
+  #"(?i)avant (le )?d[eéè]jeuner"
+  (assoc (intersect (cycle-nth :day 0)
+                    (interval (hour 10 false) (hour 12 false) false))
+         :form :part-of-day)
+
+   "après le travail"
+   #"(?i)apr[eè]s (le )?travail"
+   (assoc (intersect (cycle-nth :day 0)
+                     (interval (hour 17 false) (hour 21 false) false))
+          :form :part-of-day)
+
   "après-midi"
   #"(?i)apr[eéè]s?[ \-]?midi"
   (assoc (interval (hour 12 false) (hour 19 false) false) :form :part-of-day :latent true)

--- a/resources/languages/fr/rules/time.clj
+++ b/resources/languages/fr/rules/time.clj
@@ -9,12 +9,12 @@
   "intersect by 'de' or ','"
   [(dim :time #(not (:latent %))) #"(?i)de|," (dim :time #(not (:latent %)))] ; sequence of two tokens with a time fn
   (intersect %1 %3)
-  
+
   ; same thing, with "mais/par exemple/plutôt/" in between like "mardi, mais à 14 heures"
   "intersect by 'mais/par exemple/plutôt'"
   [(dim :time #(not (:latent %))) #"(?i)mais|par exemple|plutôt" (dim :time #(not (:latent %)))] ; sequence of two tokens with a time fn
   (intersect %1 %3)
-  
+
   "en <named-month>" ; en mars
   [#"(?i)en|au mois de?'?" {:form :month}]
   %2 ; does NOT dissoc latent
@@ -249,7 +249,7 @@
   "<day-of-week> <day-of-month> à <time-of-day>)"
   [{:form :day-of-week} (integer 1 31) {:form :time-of-day}]
   (intersect (day-of-month (:value %2)) %3)
-  
+
   ; Hours and minutes (absolute time)
   ;
   ; Assumptions:
@@ -452,7 +452,11 @@
   "fin de semaine"
   [#"(?i)(en |à la )?fin de (cette |la )?semaine"]
     (interval (day-of-week 4) (day-of-week 7) false)
-    
+
+  "en semaine"
+  [#"(?i)(pendant la|cette |en )?semaine"]
+    (cycle-nth :week 0)
+
   "season"
   #"(?i)(cet )?été" ;could be smarter and take the exact hour into account... also some years the day can change
   (interval (month-day 6 21) (month-day 9 23) false)

--- a/resources/languages/fr/rules/time.clj
+++ b/resources/languages/fr/rules/time.clj
@@ -355,7 +355,7 @@
   (assoc (interval (hour 10 false) (hour 12 false) false) :form :part-of-day :latent true)
 
   "au déjeuner"
-  #"(?i)(pendant(le )?|au)? d[eéè]jeuner"
+  #"(?i)(pendant( le)?|au)? d[eéè]jeuner"
   (assoc (interval (hour 12 false) (hour 14 false) false) :form :part-of-day :latent true)
 
   "après le déjeuner"


### PR DESCRIPTION
One case that wasn't handled in Duckling was "I prefer during the week" (I have multiple discussions where the user says that). I added the "en semaine" equivalent in the french version with a grain week.