### PR TITLE
add support for "in 24hrs" for cycles and durations

### DIFF
--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -372,6 +372,8 @@
   (datetime 2013 2 12 7 30)
 
   "in 24 hours"
+  "in 24hrs"
+  "in 24 hrs"
   (datetime 2013 2 13 4 30)
 
   "in a day"
@@ -547,8 +549,16 @@
   (datetime-interval [2013 2 12 4 31] [2013 2 12 4 34])
 
   "last 1 hour"
+  "last 1 hr"
   "last one hour"
   (datetime-interval [2013 2 12 3] [2013 2 12 4])
+
+  "last 24 hours"
+  "last twenty four hours"
+  "last twenty four hrs"
+  "last 24 hrs"
+  "last 24hrs"
+  (datetime-interval [2013 2 11 4] [2013 2 12 4])
 
   "next 3 hours"
   "next three hours"

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -21,7 +21,7 @@
    :grain :minute}
 
   "hour (cycle)"
-  #"(?i)hours?"
+  #"(?i)h(ou)?rs?"
   {:dim :cycle
    :grain :hour}
 

--- a/resources/languages/en/rules/duration.clj
+++ b/resources/languages/en/rules/duration.clj
@@ -12,7 +12,7 @@
    :grain :minute}
 
   "hour (unit-of-duration)"
-  #"(?i)h((ours?)|r)?"
+  #"(?i)h(((ou)?rs?)|r)?"
   {:dim :unit-of-duration
    :grain :hour}
 


### PR DESCRIPTION
Added support for duration and cycle hours to support "hrs" format. Previously it required you to type out "hours" instead of "hrs"

"in 24hrs"
"in 24 hrs"
"last twenty four hrs"
"last 24 hrs"
"last 24hrs"