### PR TITLE
Added slang words for year and quarter

### DIFF
--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -157,10 +157,12 @@
   "3rd quarter"
   "third qtr"
   "3rd qtr"
+  "the 3rd qtr"
   (datetime 2013 7 1 :grain :quarter)
 
   "4th quarter 2018"
   "4th qtr 2018"
+  "the 4th qtr of 2018"
   (datetime 2018 10 1 :grain :quarter)
 
   "last year"

--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -146,24 +146,33 @@
   (datetime 2013 3)
 
   "this quarter"
+  "this qtr"
   (datetime 2013 1 1 :grain :quarter)
 
   "next quarter"
+  "next qtr"
   (datetime 2013 4 1 :grain :quarter)
 
   "third quarter"
+  "3rd quarter"
+  "third qtr"
+  "3rd qtr"
   (datetime 2013 7 1 :grain :quarter)
 
   "4th quarter 2018"
+  "4th qtr 2018"
   (datetime 2018 10 1 :grain :quarter)
 
   "last year"
+  "last yr"
   (datetime 2012)
 
   "this year"
+  "this yr"
   (datetime 2013)
 
   "next year"
+  "next yr"
   (datetime 2014)
 
   "last sunday"

--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -133,6 +133,8 @@
   (datetime 2013 2 11 :grain :week)
 
   "last week"
+  "past week"
+  "previous week"
   (datetime 2013 2 4 :grain :week)
 
   "next week"

--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -129,6 +129,7 @@
 ;   ;; Cycles
 
   "this week"
+  "current week"
   "coming week"
   (datetime 2013 2 11 :grain :week)
 
@@ -172,6 +173,7 @@
   (datetime 2012)
 
   "this year"
+  "current year"
   "this yr"
   (datetime 2013)
 
@@ -458,6 +460,7 @@
   ; Seasons
 
   "this summer"
+  "current summer"
   (datetime-interval [2013 6 21] [2013 9 24])
 
   "this winter"

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -41,12 +41,12 @@
    :grain :month}
   
   "quarter (cycle)"
-  #"(?i)quarters?"
+  #"(?i)(quarter|qtr)s?"
   {:dim :cycle
    :grain :quarter}
   
   "year (cycle)"
-  #"(?i)years?"
+  #"(?i)y(ea)?rs?"
   {:dim :cycle
    :grain :year}
   

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -115,6 +115,10 @@
   [(dim :ordinal) (dim :cycle #(= :quarter (:grain %)))]
   (cycle-nth-after :quarter (dec (:value %1)) (cycle-nth :year 0))
 
+  "the <ordinal> quarter"
+  [#"(?i)the" (dim :ordinal) (dim :cycle #(= :quarter (:grain %)))]
+  (cycle-nth-after :quarter (dec (:value %2)) (cycle-nth :year 0))
+
   "<ordinal> quarter <year>"
   [(dim :ordinal) (dim :cycle #(= :quarter (:grain %))) (dim :time)]
   (cycle-nth-after :quarter (dec (:value %1)) %3)

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -55,7 +55,7 @@
   (cycle-nth (:grain %2) 0)
 
   "last <cycle>"
-  [#"(?i)last|past" (dim :cycle)]
+  [#"(?i)last|past|previous" (dim :cycle)]
   (cycle-nth (:grain %2) -1)
 
   "next <cycle>"

--- a/resources/languages/en/rules/cycles.clj
+++ b/resources/languages/en/rules/cycles.clj
@@ -51,7 +51,7 @@
    :grain :year}
   
   "this <cycle>"
-  [#"(?i)this|coming" (dim :cycle)]
+  [#"(?i)this|current|coming" (dim :cycle)]
   (cycle-nth (:grain %2) 0)
 
   "last <cycle>"

--- a/src/duckling/time/api.clj
+++ b/src/duckling/time/api.clj
@@ -55,7 +55,9 @@
                                                    :unit unit})]
                     (merge value
                            add-fields
-                           {:normalized {:value (t/period->duration value)
+                           {:normalized {:value (try
+                                                  (t/period->duration value)
+                                                (catch ArithmeticException e (.getMessage e)))
                                          :unit "second"}}))
 
         (:temperature :distance :amount-of-money :number :volume)


### PR DESCRIPTION
Also added 'the' rule for <ordinal> quarter, which allows to parse something like

'2nd week of the 2nd qtr'

Which now correctly yields

```
{
  "start": 0,
  "dim": "time",
  "end": 23,
  "body": "2nd week of the 2nd qtr",
  "value": {
    "values": [],
    "grain": "week",
    "type": "value",
    "value": "2016-04-11T00:00:00.000Z"
  }
}
```
