### PR TITLE
[FR] Add in half an hour

### DIFF
--- a/resources/languages/en/corpus/time.clj
+++ b/resources/languages/en/corpus/time.clj
@@ -352,8 +352,23 @@
   "in 60 minutes"
   (datetime 2013 2 12 5 30 0)
 
+  "about a quarter of an hour"
+  "about 1/4h"
+  "about 1/4 h"
+  "about 1/4 hour"
+  (datetime 2013 2 12 4 45 0)
+
   "in half an hour"
+  "in 1/2h"
+  "in 1/2 h"
+  "in 1/2 hour"
   (datetime 2013 2 12 5 0 0)
+
+  "for three-quarters of an hour"
+  "for 3/4h"
+  "for 3/4 h"
+  "for 3/4 hour"
+  (datetime 2013 2 12 5 15 0)
 
   "in 2.5 hours"
   "in 2 and an half hours"

--- a/resources/languages/en/rules/duration.clj
+++ b/resources/languages/en/rules/duration.clj
@@ -30,16 +30,26 @@
   #"(?i)months?"
   {:dim :unit-of-duration
    :grain :month}
-  
+
   "year (unit-of-duration)"
   #"(?i)years?"
   {:dim :unit-of-duration
    :grain :year}
-  
+
+   "quarter of an hour"
+  [#"(?i)(1/4\s?h(our)?|(a\s)?quarter of an hour)"]
+  {:dim :duration
+   :value (duration :minute 15)}
+
    "half an hour"
-  [#"(?i)(1/2\s?|half an? )hour"]
+  [#"(?i)(1/2\s?h(our)?|half an? hour)"]
   {:dim :duration
    :value (duration :minute 30)}
+
+   "three-quarters of an hour"
+  [#"(?i)(3/4\s?h(our)?|three(\s|-)quarters of an hour)"]
+  {:dim :duration
+   :value (duration :minute 45)}
 
   "fortnight" ;14 days
   #"(?i)(a|one)? fortnight"
@@ -50,7 +60,7 @@
   [(integer 0) (dim :unit-of-duration)]; duration can't be negative...
   {:dim :duration
    :value (duration (:grain %2) (:value %1))}
-    
+
   "<integer> more <unit-of-duration>"
   [(integer 0) #"(?i)more|less" (dim :unit-of-duration)]; would need to add fields at some point
   {:dim :duration
@@ -77,6 +87,14 @@
   [#"(?i)in" (dim :duration)]
   (in-duration (:value %2))
 
+  "about <duration>"
+  [#"(?i)about" (dim :duration)]
+  (in-duration (:value %2))
+
+  "for <duration>"
+  [#"(?i)for" (dim :duration)]
+  (in-duration (:value %2))
+
   "after <duration>"
   [#"(?i)after" (dim :duration)]
   (merge (in-duration (:value %2)) {:direction :after})
@@ -88,11 +106,11 @@
   "<duration> ago"
   [(dim :duration) #"(?i)ago"]
   (duration-ago (:value %1))
-  
+
   "<duration> hence"
   [(dim :duration) #"(?i)hence"]
   (in-duration (:value %1))
-  
+
   "<duration> after <time>"
   [(dim :duration) #"(?i)after" (dim :time)]
   (duration-after (:value %1) %3)

--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -772,12 +772,22 @@
   "le mois de mars"
   (datetime 2013 3)
 
-  "dans une demi heure"
-  (datetime 2013 2 12 5 0 0)
-
   "dans un quart d'heure"
+  "environ un quart d'heure"
+  "dans 1/4h"
+  "dans 1/4 h"
+  "dans 1/4 heure"
   (datetime 2013 2 12 4 45 0)
 
+  "dans une demi heure"
+  "dans 1/2h"
+  "dans 1/2 h"
+  "dans 1/2 heure"
+  (datetime 2013 2 12 5 0 0)
+
   "dans trois quarts d'heure"
+  "dans 3/4h"
+  "dans 3/4 h"
+  "dans 3/4 heure"
   (datetime 2013 2 12 5 15 0)
 )

--- a/resources/languages/fr/corpus/time.clj
+++ b/resources/languages/fr/corpus/time.clj
@@ -771,4 +771,13 @@
   "au mois de mars"
   "le mois de mars"
   (datetime 2013 3)
+
+  "dans une demi heure"
+  (datetime 2013 2 12 5 0 0)
+
+  "dans un quart d'heure"
+  (datetime 2013 2 12 4 45 0)
+
+  "dans trois quarts d'heure"
+  (datetime 2013 2 12 5 15 0)
 )

--- a/resources/languages/fr/rules/duration.clj
+++ b/resources/languages/fr/rules/duration.clj
@@ -37,17 +37,17 @@
    :grain :year}
 
    "un quart heure"
-  [#"(?i)(un|1) quart d'heure"]
+  [#"(?i)(1/4\s?h(eure)?|(un|1) quart d'heure)"]
   {:dim :duration
    :value (duration :minute 15)}
 
    "une demi heure"
-  [#"(?i)(1|une) demi(e)?(\s|-)heure"]
+  [#"(?i)(1/2\s?h(eure)?|(1|une) demi(e)?(\s|-)heure)"]
   {:dim :duration
    :value (duration :minute 30)}
 
    "trois quarts d'heure"
-  [#"(?i)(3|trois) quart(s)? d'heure"]
+  [#"(?i)(3/4\s?h(eure)?|(3|trois) quart(s)? d'heure)"]
   {:dim :duration
    :value (duration :minute 45)}
 
@@ -63,6 +63,10 @@
 
   "dans <duration>"
   [#"(?i)dans" (dim :duration)]
+  (in-duration (:value %2))
+
+  "environ <duration>"
+  [#"(?i)environ" (dim :duration)]
   (in-duration (:value %2))
 
   "il y a <duration>"

--- a/resources/languages/fr/rules/duration.clj
+++ b/resources/languages/fr/rules/duration.clj
@@ -30,12 +30,27 @@
   #"(?i)mois?"
   {:dim :unit-of-duration
    :grain :month}
-  
+
   "année (unit-of-duration)"
   #"(?i)an(n[ée]e?)?s?"
   {:dim :unit-of-duration
    :grain :year}
-  
+
+   "un quart heure"
+  [#"(?i)(un|1) quart d'heure"]
+  {:dim :duration
+   :value (duration :minute 15)}
+
+   "une demi heure"
+  [#"(?i)(1|une) demi(e)?(\s|-)heure"]
+  {:dim :duration
+   :value (duration :minute 30)}
+
+   "trois quarts d'heure"
+  [#"(?i)(3|trois) quart(s)? d'heure"]
+  {:dim :duration
+   :value (duration :minute 45)}
+
   "<integer> <unit-of-duration>"
   [(integer 0) (dim :unit-of-duration)] ;prevent negative duration...
   {:dim :duration


### PR DESCRIPTION
Add 3 durations
* dans `une demi heure` (in half an hour)
* dans `un quart d'heure` (a quarter of an hour)
* dans `trois quarts d'heure` (Three-quarters of an hour)

Those expressions are very common in french. I looked at how it was done for `in half an hour` for the english version then copy/pasted it and translate it to french. I also added two other expressions that relied upon the same technique.

This should fix the issue #175 