### PR TITLE
Fix and extend italian support for time and durations

### DIFF
--- a/resources/languages/it/corpus/time.clj
+++ b/resources/languages/it/corpus/time.clj
@@ -7,11 +7,12 @@
   "immediatamente"
   "in questo momento"
   (datetime 2013 2 12 4 30 00)
-  
+
   "ora"
   "di oggi"
   "oggi"
   "adesso"
+  "in giornata"
   (datetime 2013 2 12)
 
   "ieri"
@@ -19,11 +20,18 @@
 
   "domani"
   (datetime 2013 2 13)
-  
+
   "Il giorno dopo domani"
   "dopodomani"
   (datetime 2013 2 14)
-  
+
+  "Lunedì 18 febbraio"
+  (datetime 2013 2 18 :day-of-week 1 :day 18 :month 2)
+
+  "martedì"
+  "Martedì 19"
+  (datetime 2013 2 19)
+
   "l'altro ieri"
   "altroieri"
   (datetime 2013 2 10)
@@ -42,7 +50,7 @@
   "mer"
   "mer."
   (datetime 2013 2 13 :day-of-week 3)
-  
+
   "mercoledi 13 feb"
   "il 13 febbraio"
   (datetime 2013 2 13 :day-of-week 3 :day 13 :month 2)
@@ -68,13 +76,22 @@
   "dom"
   "dom."
   (datetime 2013 2 17)
-  
+
   "domenica 10 febbraio"
   (datetime 2013 2 10 :day-of-week 7 :day 13 :month 2) ; with current look-forward default...
-  
+
   "il 1 marzo"
-  "prima di marzo"
+  "primo marzo"
+  "primo di marzo"
+  "il 1º marzo"
   (datetime 2013 3 1 :day 1 :month 3)
+
+  "prima di marzo"
+  (datetime 2013 3)
+
+  "le idi di marzo"
+  "idi di marzo"
+  (datetime 2013 3 15 :month 3)
 
   "3 marzo 2015"
   "3/3/2015"
@@ -87,7 +104,7 @@
   "15/2"
   "il 15/02"
   (datetime 2013 2 15 :day 15 :month 2)
-  
+
   "31/10/1974"
   "31/10/74"
   (datetime 1974 10 31 :day 31 :month 10 :year 1974)
@@ -95,37 +112,40 @@
   "martedì scorso"
   (datetime 2013 2 5 :day-of-week 2)
 
-  "martedì prossimo" 
+  "martedì prossimo"
   "il martedì dopo"
   (datetime 2013 2 19 :day-of-week 2)
 
-  "mercoledì prossimo" 
+  "mercoledì prossimo"
   ;"mercoledi fra una settimana"
   (datetime 2013 2 20 :day-of-week 3)
+
+  "ottobre 2014"
+  (datetime 2014 10 :year 2014 :month 10)
 
    ;; Cycles
 
   "questa settimana"
   (datetime 2013 2 11 :grain :week)
-  
+
   "la settimana scorsa"
   (datetime 2013 2 4 :grain :week)
-  
+
   "la settimana prossima"
   (datetime 2013 2 18 :grain :week)
-  
+
   "il mese scorso"
   (datetime 2013 1)
 
   "il mese prossimo"
   (datetime 2013 3)
-  
+
   "l'anno scorso"
   (datetime 2012)
-  
+
   "quest'anno"
   (datetime 2013)
-  
+
   "il prossimo anno"
   (datetime 2014)
 
@@ -133,45 +153,131 @@
   ;"domenica della scorsa settimana"
   (datetime 2013 2 10 :day-of-week 7)
 
+  "lunedì di questa settimana"
+  (datetime 2013 2 11 :day-of-week 1)
+
+  "martedì di questa settimana"
+  (datetime 2013 2 12 :day-of-week 2)
+
+  "mercoledì di questa settimana"
+  (datetime 2013 2 13 :day-of-week 3)
+
+  "dopo domani alle 17"
+  "dopodomani alle 5 del pomeriggio"
+  (datetime 2013 2 14 17)
+
+  "ultimo lunedì di marzo"
+  (datetime 2013 3 25 :day-of-week 1)
+
+  "ultima domenica di marzo 2014"
+  (datetime 2014 3 30 :day-of-week 7)
+
+  "il terzo giorno di ottobre"
+  (datetime 2013 10 3)
+
+  "prima settimana di ottobre 2014"
+  (datetime 2014 10 6 :grain :week)
+
+  "la settimana del 6 ottobre"
+  "la settimana del 7 ottobre"
+  (datetime 2013 10 7 :grain :week)
+
+  "l'ultimo giorno di ottobre 2015"
+  "l'ultimo giorno dell'ottobre 2015"
+  (datetime 2015 10 31)
+
+  "l'ultima settimana di settembre 2014"
+  (datetime 2014 9 22 :grain :week)
+
+  ;; nth of
+  "primo martedì di ottobre"
+  "primo martedì in ottobre"
+  "1° martedì del mese di ottobre"
+  "1º martedì del mese di ottobre"
+  (datetime 2013 10 1)
+
+  "terzo martedì di settembre 2014"
+  (datetime 2014 9 16)
+
+  "primo mercoledì di ottobre 2014"
+  (datetime 2014 10 1)
+
+  "secondo mercoledì di ottobre 2014"
+  (datetime 2014 10 8)
+
+  ;; nth after
+
+  "terzo martedì dopo natale 2014"
+  (datetime 2015 1 13)
+
+  "il mese dopo natale 2015"
+  (datetime 2016 1)
+
   ;; Hours
 
   "alle 3 di pomeriggio"
   "le tre di pomeriggio"
+  "alle 3 del pomeriggio"
+  "le tre del pomeriggio"
   (datetime 2013 2 12 15)
+
+  "circa alle 3 del pomeriggio" ;; FIXME pm overrides precision
+  (datetime 2013 2 12 15 :hour 3) ;; :precision "approximate"
+
+  "per le 15"
+  "verso le 15"
+  (datetime 2013 2 12 15) ;; :precision "approximate"
 
   "3:00"
   "03:00"
-  (datetime 2013 2 12 15 0 :hour 15 :minute 0)
+  (datetime 2013 2 13 3 0 :hour 3 :minute 0)
 
-  "alle tre e un quarto"
-  "3:15 di pomeriggio"
   "15:15"
   (datetime 2013 2 12 15 15 :hour 15 :minute 15)
 
-  "alle tre e venti"
-  "3:20 di pomeriggio"
-  (datetime 2013 2 12 15 20 :hour 3 :minute 20)
+  "3:15 di pomeriggio"
+  "3:15 del pomeriggio"
+  "3 e un quarto di pomeriggio"
+  "tre e un quarto di pomeriggio"
+  (datetime 2013 2 12 15 15)
 
-  ; "alle tre week-end mezzo"
-  ; "3:30 di pomeriggio"
+  "alle tre e venti di pomeriggio"
+  "alle tre e venti del pomeriggio"
+  "3:20 di pomeriggio"
+  "3:20 del pomeriggio"
+  "15:20 del pomeriggio"
+  (datetime 2013 2 12 15 20)
+
+  "alle tre e venti"
+  "tre e 20"
+  "3 e 20"
+  "3:20"
+  "3 20"
+  (datetime 2013 2 13 3 20 :hour 3 :minute 20)
 
   "15:30"
   (datetime 2013 2 12 15 30 :hour 15 :minute 30)
 
   "a mezzogiorno meno un quarto"
-  "quarto a mezzogiorno"
+  "mezzogiorno meno un quarto"
+  "un quarto a mezzogiorno"
   "11:45 del mattino"
   (datetime 2013 2 12 11 45 :hour 11 :minute 45)
 
   "alle 3 del mattino"
   (datetime 2013 2 13 3 :hour 3)
-    
-  "alle 19:30 il venerdì 20 settembre"
+
+  "alle 19:30 di venerdì 20 settembre"
+  "alle 19:30 venerdì 20 settembre"
+  "venerdì 20 settembre alle 19:30"
+  "il 20 settembre alle 19:30"
   (datetime 2013 9 20 19 30 :hour 19 :minute 30 :day-of-week 5 :day 20 :month 9)
 
   ;; Involving periods   ; look for grain-after-shift
 
   "questo week-end"
+  "questo fine settimana"
+  "questo finesettimana"
   (datetime-interval [2013 2 15 18] [2013 2 18 00])
 
   "lunedi mattina"
@@ -183,46 +289,387 @@
   "mattino di 15 febbraio"
   (datetime-interval [2013 2 15 4] [2013 2 15 12])
 
-   ; Intervals involving cycles
-  
-  "ultimi 2 secondi" 
-  "ultimi due secondi"
+  "8 di stasera"
+  "8 della sera"
+  (datetime 2013 2 12 20)
+
+  ;; Mixing date and time
+
+  "venerdì 20 settembre alle 7:30 del pomeriggio"
+  (datetime 2013 9 20 19 30 :hour 7 :minute 30 :meridiem :pm)
+
+  "alle 9 di sabato"
+  "sabato alle 9"
+  (datetime 2013 2 16 9 :day-of-week 6 :hour 9 :meridiem :am)
+
+  ; Seasons
+
+  "quest'estate"
+  "questa estate"
+  "in estate"
+  (datetime-interval [2013 6 21] [2013 9 24])
+
+  "quest'inverno"
+  "questo inverno"
+  "in inverno"
+  (datetime-interval [2012 12 21] [2013 3 21])
+
+  "il prossimo autunno"
+  (datetime-interval [2014 9 23] [2014 12 22])
+
+  ; IT holidays
+
+  "natale"
+  "il giorno di natale"
+  (datetime 2013 12 25)
+
+  "vigilia di natale"
+  (datetime 2013 12 24)
+
+  "vigilia di capodanno"
+  "san silvestro"
+  (datetime 2013 12 31)
+
+  "notte di san silvestro"
+  (datetime-interval [2014 1 1 0] [2014 1 1 4])
+
+  "capodanno"
+  "primo dell'anno"
+  (datetime 2014 1 1)
+
+  "epifania"
+  "befana"
+  (datetime 2014 1 6)
+
+  "san valentino"
+  (datetime 2013 2 14)
+
+  "festa del papà"
+  "festa del papa"
+  "festa di san giuseppe"
+  "san giuseppe"
+  (datetime 2013 3 19)
+
+  "anniversario della liberazione"
+  "la liberazione"
+  (datetime 2013 4 25)
+
+  "festa del lavoro"
+  "festa dei lavoratori"
+  "giorno dei lavoratori"
+  "primo maggio"
+  (datetime 2013 5 1)
+
+  "festa della mamma"
+  (datetime 2013 5 12)
+
+  "festa della repubblica"
+  (datetime 2013 6 2)
+
+  "ferragosto"
+  "assunzione"
+  (datetime 2013 8 15)
+
+  "halloween"
+  (datetime 2013 10 31)
+
+  "tutti i santi"
+  "ognissanti"
+  (datetime 2013 11 1)
+
+  "giorno dei morti"
+  "commemorazione dei defunti"
+  (datetime 2013 11 2)
+
+  "santo stefano"
+  (datetime 2013 12 26)
+
+  ; Part of day (morning, afternoon...)
+
+  "questa sera"
+  "sta sera"
+  "stasera"
+  "in serata"
+  "nella sera"
+  (datetime-interval [2013 2 12 18] [2013 2 13 00])
+
+  "in settimana"
+  "per la settimana"
+  (datetime-interval [2013 2 12 4 30 00] [2013 2 18])
+
+  "stanotte"
+  (datetime-interval [2013 2 13 0] [2013 2 13 04])
+
+  "ultimo weekend"
+  (datetime-interval [2013 2 8 18] [2013 2 11 00])
+
+  "domani in serata"
+  "domani sera"
+  "nella serata di domani"
+  (datetime-interval [2013 2 13 18] [2013 2 14 00])
+
+  "domani notte"
+  "domani in nottata"
+  "nella nottata di domani"
+  "nella notte di domani"
+  (datetime-interval [2013 2 14 00] [2013 2 14 04])
+
+  "domani a pranzo"
+  (datetime-interval [2013 2 13 12] [2013 2 13 14])
+
+  "ieri sera"
+  (datetime-interval [2013 2 11 18] [2013 2 12 00])
+
+  "questo weekend"
+  "questo week-end"
+  (datetime-interval [2013 2 15 18] [2013 2 18 00])
+
+  "lunedì mattina"
+  "nella mattinata di lunedì"
+  "lunedì in mattinata"
+  "lunedì nella mattina"
+  (datetime-interval [2013 2 18 4] [2013 2 18 12])
+
+  "il 15 febbraio in mattinata"
+  "mattina del 15 febbraio"
+  "15 febbraio mattina"
+  (datetime-interval [2013 2 15 4] [2013 2 15 12])
+
+  ; Intervals involving cycles
+
+  "gli ultimi 2 secondi"
+  "gli ultimi due secondi"
+  "i 2 secondi passati"
+  "i due secondi passati"
   (datetime-interval [2013 2 12 4 29 58] [2013 2 12 4 30 00])
 
-  "prossimi 3 secondi"
-  "prossimi tre secondi"
+  "i prossimi 3 secondi"
+  "i prossimi tre secondi"
   (datetime-interval [2013 2 12 4 30 01] [2013 2 12 4 30 04])
 
-  "ultimi 2 minuti"
-  "ultimi due minuti"
+  "gli ultimi 2 minuti"
+  "gli ultimi due minuti"
+  "i 2 minuti passati"
+  "i due minuti passati"
   (datetime-interval [2013 2 12 4 28] [2013 2 12 4 30])
 
-  "ultime 2 ore"
-  "ultime due ore"
+  "i prossimi 3 minuti"
+  "i prossimi tre minuti"
+  (datetime-interval [2013 2 12 4 31] [2013 2 12 4 34])
+
+  "l'ultima ora"
+  (datetime-interval [2013 2 12 3] [2013 2 12 4])
+
+  "le ultime 2 ore"
+  "le ultime due ore"
+  "le scorse due ore"
+  "le due ore scorse"
+  "le scorse 2 ore"
+  "le 2 ore scorse"
   (datetime-interval [2013 2 12 2] [2013 2 12 4])
 
-  "prossime 3 ore"
+  "le ultime 24 ore"
+  "le ultime ventiquattro ore"
+  "le 24 ore passate"
+  "le ventiquattro ore passate"
+  (datetime-interval [2013 2 11 4] [2013 2 12 4])
+
+  "le prossime 3 ore"
+  "le prossime tre ore"
   (datetime-interval [2013 2 12 5] [2013 2 12 8])
 
-  "ultimi 2 giorni"
+  "gli ultimi 2 giorni"
+  "gli ultimi due giorni"
+  "i 2 giorni passati"
+  "i due giorni passati"
+  "gli scorsi due giorni"
+  "i 2 giorni scorsi"
+  "i due giorni scorsi"
   (datetime-interval [2013 2 10] [2013 2 12])
-    
-  "ultime due settimane"
+
+  "i prossimi 3 giorni"
+  "i prossimi tre giorni"
+  (datetime-interval [2013 2 13] [2013 2 16])
+
+  "i prossimi giorni"
+  (datetime-interval [2013 2 13] [2013 2 16])
+
+  "le ultime 2 settimane"
+  "le ultime due settimane"
+  "le 2 ultime settimane"
+  "le due ultime settimane"
   (datetime-interval [2013 1 28 :grain :week] [2013 2 11 :grain :week])
 
-  "prossime tre settimane"
+  "le prossime 3 settimane"
+  "le prossime tre settimane"
+  "le 3 prossime settimane"
+  "le tre prossime settimane"
   (datetime-interval [2013 2 18 :grain :week] [2013 3 11 :grain :week])
 
-  "ultimi due mesi"
+  "gli ultimi 2 mesi"
+  "gli ultimi due mesi"
+  "i 2 mesi passati"
+  "i due mesi passati"
+  "i due mesi scorsi"
+  "i 2 mesi scorsi"
+  "gli scorsi due mesi"
+  "gli scorsi 2 mesi"
   (datetime-interval [2012 12] [2013 02])
 
-  "prossimi 3 mesi"
+  "i prossimi 3 mesi"
+  "i prossimi tre mesi"
+  "i 3 prossimi mesi"
+  "i tre prossimi mesi"
   (datetime-interval [2013 3] [2013 6])
 
-  "ultimi 2 anni"
+  "gli ultimi 2 anni"
+  "gli ultimi due anni"
+  "i 2 anni passati"
+  "i due anni passati"
+  "i 2 anni scorsi"
+  "i due anni scorsi"
+  "gli scorsi due anni"
+  "gli scorsi 2 anni"
   (datetime-interval [2011] [2013])
-  
-  "prossimi tre anni"
-  (datetime-interval [2014] [2017]) 
-  
+
+  "i prossimi 3 anni"
+  "i prossimi tre anni"
+  (datetime-interval [2014] [2017])
+
+  ; Explicit intervals
+
+  "13-15 luglio"
+  "dal 13 al 15 luglio"
+  "tra il 13 e il 15 luglio"
+  "tra 13 e 15 luglio"
+  "13 luglio - 15 luglio"
+  (datetime-interval [2013 7 13] [2013 7 16])
+
+  "8 ago - 12 ago"
+  (datetime-interval [2013 8 8] [2013 8 13])
+
+  "9:30 - 11:00"
+  (datetime-interval [2013 2 12 9 30] [2013 2 12 11 1])
+
+  "dalle 9:30 alle 11:00 di giovedì"
+  "tra le 9:30 e le 11:00 di giovedì"
+  "9:30 - 11:00 giovedì"
+  "giovedì dalle 9:30 alle 11:00"
+  "giovedì tra le 9:30 e le 11:00"
+  (datetime-interval [2013 2 14 9 30] [2013 2 14 11 1])
+
+  "dalle 9 alle 11 di giovedì"
+  "tra le 9 e le 11 di giovedì"
+  "9 - 11 giovedì"
+  "giovedì dalle nove alle undici"
+  "giovedì tra le nove e le undici"
+  (datetime-interval [2013 2 14 9] [2013 2 14 12])
+
+  "dalle tre all'una di giovedì"
+  (datetime-interval [2013 2 14 3] [2013 2 14 14])
+
+  "domani dalle 15:00 alle 17:00"
+  (datetime-interval [2013 2 13 15 00] [2013 2 13 17 01])
+
+  "11:30-13:30" ; go train this rule!
+  "11:30-13:30"
+  "11:30-13:30"
+  "11:30-13:30"
+  "11:30-13:30"
+  "11:30-13:30"
+  "11:30-13:30"
+  (datetime-interval [2013 2 12 11 30] [2013 2 12 13 31])
+
+  "13:30 di sabato 21 settembre"
+  "13:30 del 21 settembre"
+  (datetime 2013 9 21 13 30)
+
+  "in due settimane"
+  "per due settimane"
+  (datetime-interval [2013 2 12 4 30 0] [2013 2 26])
+
+  "fino alle 14:00"
+  (datetime-interval [2013 2 12 4 30 0] [2013 2 12 14 00])
+
+  "entro le 14:00"
+  (datetime 2013 2 12 14 0 :direction :before)
+
+  "entro la fine del mese"
+  (datetime 2013 3 :direction :before)
+
+  "entro la fine dell'anno"
+  (datetime 2014 :direction :before)
+
+  "fino alla fine del mese"
+  (datetime-interval [2013 2 12 4 30 0] [2013 3 1 0])
+
+  "fino alla fine dell'anno"
+  (datetime-interval [2013 2 12 4 30 0] [2014 1 1])
+
+  ; Timezones
+
+  "4 CET"
+  (datetime 2013 2 12 4 :hour 4 :timezone "CET")
+
+  "16 CET"
+  (datetime 2013 2 12 16 :hour 16 :timezone "CET")
+
+  "giovedì alle 8:00 GMT"
+  (datetime 2013 2 14 8 00 :timezone "GMT")
+
+  ;; Bookface tests
+  "domani alle 14"
+  (datetime 2013 2 13 14)
+
+  "alle 14"
+  "alle 2 del pomeriggio"
+  (datetime 2013 2 12 14)
+
+  "25/4 alle 16:00"
+  (datetime 2013 4 25 16 0)
+
+  "3 del pomeriggio di domani"
+  "15 del pomeriggio di domani"
+  (datetime 2013 2 13 15)
+
+  "dopo le 14"
+  (datetime 2013 2 12 14 :direction :after)
+
+  "prima delle 11"
+  (datetime 2013 2 12 11 :direction :before)
+
+  "nel pomeriggio"
+  (datetime-interval [2013 2 12 12] [2013 2 12 19])
+
+  "alle 13:30"
+  "13:30"
+  "1:30 del pomeriggio"
+  (datetime 2013 2 12 13 30)
+
+  "in 15 minuti"
+  "tra 15 minuti"
+  (datetime 2013 2 12 4 45 0)
+
+  "10:30"
+  (datetime 2013 2 12 10 30)
+
+  "mattina"
+  "mattinata"
+  "mattino"
+  (datetime-interval [2013 2 12 4] [2013 2 12 12])
+
+  "prossimo lunedì"
+  (datetime 2013 2 25 :day-of-week 1)
+
+  "alle 12"
+  "a mezzogiorno"
+  (datetime 2013 2 12 12)
+
+  "alle 24"
+  "a mezzanotte"
+  (datetime 2013 2 13 0)
+
+  "marzo"
+  "in marzo"
+  (datetime 2013 3)
 )

--- a/resources/languages/it/rules/cycles.clj
+++ b/resources/languages/it/rules/cycles.clj
@@ -1,6 +1,11 @@
 ; See comments in en.cycles.clj
 
 (
+  ; intersect with "di" "della", ... in between like "Sunday of last week"
+  "intersect by \"di\", \"della\", \"del\""
+  [(dim :time #(not (:latent %))) #"(?i)di|del(la)?" (dim :time #(not (:latent %)))] ; sequence of two tokens with a time fn
+  (intersect %1 %3)
+
   "seconde (cycle)"
   #"(?i)second[oi]"
   {:dim :cycle
@@ -30,18 +35,22 @@
   #"(?i)mes[ei]"
   {:dim :cycle
    :grain :month}
-  
+
   "année (cycle)"
   #"(?i)ann?[oi]"
   {:dim :cycle
    :grain :year}
-  
+
   "this <cycle>"
-  [#"(?i)(in )?quest['oa]" (dim :cycle)]
+  [#"(?i)(in )?quest['oa]|per (il|l['a])" (dim :cycle)]
   (cycle-nth (:grain %2) 0)
 
   "the <cycle> last"
-  [#"(?i)l'|il|la" (dim :cycle) #"(?i)(ultim|scors)[oa]"]
+  [#"(?i)l'|il|la" (dim :cycle) #"(?i)(scors|passat)[oa]"]
+  (cycle-nth (:grain %2) -1)
+
+  "the last <cycle>"
+  [#"(?i)(l' ?ultim|(il|la) passat|l[ao] scors)[oa]" (dim :cycle)]
   (cycle-nth (:grain %2) -1)
 
   "the <cycle> next"
@@ -49,30 +58,66 @@
   (cycle-nth (:grain %2) 1)
 
   "next <cycle> "
-  [#"(?i)(l'|il|la) prossim[oa]" (dim :cycle)]
+  [#"(?i)(il|la) prossim[oa]" (dim :cycle)]
   (cycle-nth (:grain %2) 1)
-  
-  ; "le <cycle> après|suivant <time>"
-  ; [#"(?i)l[ea']? ?" (dim :cycle) #"(?i)suivante?|apr[eèé]s" (dim :time)]
-  ; (cycle-nth-after (:grain %2) 1 %4)
-  
-  ; "le <cycle> avant|précédent <time>"
-  ; [#"(?i)l[ea']? ?" (dim :cycle) #"(?i)avant|pr[ée]c[ée]dent" (dim :time)]
-  ; (cycle-nth-after (:grain %2) -1 %4)
-  
-  "n last <cycle>"
-  [#"(?i)(scors|ultim)[aoei]" (integer 2 9999)(dim :cycle)]
+
+  "le <time> prossime <cycle>|i <time> prossimi <cycle>"
+  [#"(?i)i|le" (dim :time) #"(?i)prossim[ie]" (dim :cycle)]
+  (cycle-nth-after (:grain %4) 1 %2)
+
+  "le prossime <time> <cycle>|i prossimi <time> <cycle>"
+  [#"(?i)(i|le) prossim[ie]" (dim :time) (dim :cycle)]
+  (cycle-nth-after (:grain %3) 1 %2)
+
+  "il <cycle> dopo <time>"
+  [#"(?i)l[a']|il" (dim :cycle) #"(?i)dopo" (dim :time)]
+  (cycle-nth-after (:grain %2) 1 %4)
+
+  "i|le n <cycle> passati|passate"
+  [#"(?i)(i|le)" (integer 2 9999) (dim :cycle) #"(?i)(scors|passat)[ie]"]
   (cycle-n-not-immediate (:grain %3) (- (:value %2)))
-  
-  "n next <cycle>"
-  [#"(?i)prossim[oaei]" (integer 2 9999) (dim :cycle)]
+
+  "gli ultimi <n> <cycle>"
+  [#"(?i)((le|gli) )?(scors|ultim)[ei]" (integer 2 9999) (dim :cycle)]
+  (cycle-n-not-immediate (:grain %3) (- (:value %2)))
+
+  "gli <n> ultimi <cycle>"
+  [#"(?i)(gl)i|le" (integer 2 9999) #"(?i)(scors|ultim)[ei]" (dim :cycle)]
+  (cycle-n-not-immediate (:grain %4) (- (:value %2)))
+
+  "l'ultima|la scorsa <cycle>"
+  [#"(?i)(l'ultima|la scorsa)" (dim :cycle)]
+  (cycle-n-not-immediate (:grain %2) -1)
+
+  "next n <cycle>"
+  [#"(?i)(i|le) prossim[ei]" (integer 2 9999) (dim :cycle)]
   (cycle-n-not-immediate (:grain %3) (:value %2))
 
-  ; "n <cycle> passes|precedents"
-  ; [(integer 2 9999) (dim :cycle) #"(?i)pass[eèé][eèé]?s?"]
-  ; (cycle-n-not-immediate (:grain %2) (- (:value %1)))
-  
-  ; "n <cycle> suivants"
-  ; [(integer 2 9999) (dim :cycle) #"(?i)suivante?s?" ]
-  ; (cycle-n-not-immediate (:grain %2) (:value %1))
+  "next n <cycle>"
+  [#"(?i)(i|le)" (integer 2 9999) #"(?i)prossim[ei]" (dim :cycle)]
+  (cycle-n-not-immediate (:grain %4) (:value %2))
+
+  "last <day-of-week> of <time>"
+  [#"(?i)(l')?ultim[oa]" {:form :day-of-week} #"(?i)di|del(l[a'])?" (dim :time)]
+  (pred-last-of %2 %4)
+
+  "the nth <time> of <time>"
+  [#"(?i)il|l[a']" (dim :ordinal) (dim :time) #"(?i)di|del(l[a'])?" (dim :time)]
+  (pred-nth (intersect %5 %3) (dec (:value %2)))
+
+  "nth <time> of <time>"
+  [(dim :ordinal) (dim :time) #"(?i)di|del(l[a'])?" (dim :time)]
+  (pred-nth (intersect %4 %2) (dec (:value %1)))
+
+  "<ordinal> <cycle> of <time>"
+  [(dim :ordinal) (dim :cycle) #"(?i)di|del(l[a'])?" (dim :time)]
+  (cycle-nth-after-not-immediate (:grain %2) (dec (:value %1)) %4)
+
+  "the <ordinal> <cycle> of <time>"
+  [#"(?i)il|l[a']" (dim :ordinal) (dim :cycle) #"(?i)di|del(l[a'])?" (dim :time)]
+  (cycle-nth-after-not-immediate (:grain %3) (dec (:value %2)) %5)
+
+  "the <cycle> of <time>"
+  [#"(?i)il|la" (dim :cycle) #"(?i)del" (dim :time)]
+  (cycle-nth-after-not-immediate (:grain %2) 0 %4)
 )

--- a/resources/languages/it/rules/duration.clj
+++ b/resources/languages/it/rules/duration.clj
@@ -9,12 +9,12 @@
   "minute (unit-of-duration)"
   #"(?i)min(ut[oi])?"
   {:dim :unit-of-duration
-   :grain :minute} 
+   :grain :minute}
 
   "hour (unit-of-duration)"
   #"(?i)or[ae]"
   {:dim :unit-of-duration
-   :grain :hour} 
+   :grain :hour}
 
   "day (unit-of-duration)"
   #"(?i)giorn[oi]"
@@ -30,12 +30,12 @@
   #"(?i)mes[ei]"
   {:dim :unit-of-duration
    :grain :month}
-  
+
   "year (unit-of-duration)"
   #"(?i)ann[oi]"
   {:dim :unit-of-duration
    :grain :year}
-  
+
   "<integer> <unit-of-duration>"
   [(integer 0) (dim :unit-of-duration)] ;prevent negative duration...
   {:dim :duration
@@ -48,7 +48,7 @@
 
 
   "in/after <duration>"
-  [#"(?i)fra|in|dopo" (dim :duration)]
+  [#"(?i)[tf]ra|in|dopo" (dim :duration)]
   (in-duration (:value %2))
 
   "<duration> ago"

--- a/resources/languages/it/rules/numbers.clj
+++ b/resources/languages/it/rules/numbers.clj
@@ -108,7 +108,7 @@
               (-> %1 :groups first clojure.string/lower-case))}
 
   "ordinal (digits)"
-  #"0*(\d+) ?[ª°]"
+  #"0*(\d+) ?[ª°°]"
   {:dim :ordinal
    :value (read-string (first (:groups %1)))}  ; read-string not the safest
 

--- a/resources/languages/it/rules/time.clj
+++ b/resources/languages/it/rules/time.clj
@@ -10,6 +10,10 @@
   [(dim :time #(not (:latent %))) #"(?i)de" (dim :time #(not (:latent %)))] ; sequence of two tokens with a time fn
   (intersect %1 %3)
 
+  "in <named-month>" ; in September
+  [#"(?i)in|del mese( di)?" {:form :month}]
+  %2 ; does NOT dissoc latent
+
   ;;
 
   "named-day"
@@ -91,13 +95,77 @@
   ; Holiday TODO: check online holidays
   ; or define dynamtc rule (last thursday of october..)
 
+  "christmas"
+  #"(?i)((il )?giorno di )?natale"
+  (month-day 12 25)
+
+  "christmas eve"
+  #"(?i)(la )?vigilia di natale"
+  (month-day 12 24)
+
+  "new year's eve"
+  #"(?i)((la )?vigilia di capodanno|san silvestro)"
+  (month-day 12 31)
+
+  "new year's day"
+  #"(?i)(capodanno|primo dell' ?anno)"
+  (month-day 1 1)
+
+  "epifania"
+  #"(?i)(epifania|befana)"
+  (month-day 1 6)
+
+  "valentine's day"
+  #"(?i)san valentino"
+  (month-day 2 14)
+
+  "festa del papà"
+  #"(?i)festa del pap[aà]|(festa di )?san giuseppe"
+  (month-day 3 19)
+
+  "festa della liberazione"
+  #"(?i)((festa|anniversario) della|la) liberazione"
+  (month-day 4 25)
+
+  "festa del lavoro"
+  #"(?i)festa del lavoro|(festa|giorno) dei lavoratori"
+  (month-day 5 1)
+
+  "festa della repubblica"
+  #"(?i)festa della repubblica"
+  (month-day 6 2)
+
+  "ferragosto"
+  #"(?i)ferragosto|assunzione"
+  (month-day 8 15)
+
+  "halloween day"
+  #"(?i)hall?owe?en"
+  (month-day 10 31)
+
+  "ognissanti"
+  #"(?i)(tutti i |ognis)santi"
+  (month-day 11 1)
+
+  "commemorazione dei defunti"
+  #"(?i)(giorno dei|commemorazione dei) (morti|defunti)"
+  (month-day 11 2)
+
+  "santo stefano"
+  #"(?i)santo stefano"
+  (month-day 12 26)
+
+  "Mother's Day";second Sunday in May.
+  #"(?i)festa della mamma"
+  (intersect (day-of-week 7) (month 5) (cycle-nth-after :week 1 (month-day 5 1)))
+
 
   "right now"
   #"(subito|immediatamente|proprio adesso|in questo momento)"
   (cycle-nth :second 0)
 
   "now"
-  #"(?i)(ora|al momento|attualmented|adesso|(di )?oggi)"
+  #"(?i)(ora|al momento|attualmente|adesso|(di )?oggi|in giornata)"
   (cycle-nth :day 0)
 
   "tomorrow"
@@ -107,6 +175,14 @@
   "yesterday"
   #"(?i)ieri"
   (cycle-nth :day -1)
+
+  "EOM|End of month"
+  #"(?i)fine del mese"
+  (cycle-nth :month 1)
+
+  "EOY|End of year"
+  #"(?i)fine dell' ?anno"
+  (cycle-nth :year 1)
 
   "the day after tomorrow"
   #"(?i)(il giorno )?dopo\s?domani"
@@ -130,7 +206,7 @@
   ;; "this month" => now is part of it
   ; See also: cycles in en.cycles.clj
   "this <time>"
-  [#"(?i)quest[oaie]" (dim :time)]
+  [#"(?i)quest[oaie']" (dim :time)]
   (pred-nth %2 0)
 
   "next <time>"
@@ -141,13 +217,42 @@
   [(dim :time) #"(?i)dopo|prossim[ao]"]
   (pred-nth %1 1)
 
+  "prossimi <unit-of-duration>"
+  [#"(?i)(i|le) prossim[ie]" (dim :unit-of-duration)]
+  (interval (cycle-nth (:grain %2) 1) (cycle-nth (:grain %2) 3) true)
+
   "<time> last"
-  [(dim :time) #"(?i)(ultim|scors)[oaie]"]
+  [(dim :time) #"(?i)(ultim|scors|passat)[oaie]"]
   (pred-nth %1 -1)
 
   "last <time> "
-  [#"(?i)(ultim|scors)[oaie]" (dim :time)]
+  [#"(?i)(ultim|scors|passat)[oaie]" (dim :time)]
   (pred-nth %2 -1)
+
+  "last <day-of-week> of <time>"
+  [#"(?i)(l')ultim[oa]" {:form :day-of-week} #"(?i)di" (dim :time)]
+  (pred-last-of %2 %4)
+
+  "last <cycle> of <time>"
+  [#"(?i)(l')ultim[oa]" (dim :cycle) #"(?i)di|del(l[oa'])" (dim :time)]
+  (cycle-last-of %2 %4)
+
+  ; Ordinals
+  "nth <time> of <time>"
+  [(dim :ordinal) (dim :time) #"(?i)di|del(l[oa'])|in" (dim :time)]
+  (pred-nth (intersect %4 %2) (dec (:value %1)))
+
+  "nth <time> of <time>"
+  [#"(?i)il|l'" (dim :ordinal) (dim :time) #"(?i)di|del(l[oa'])|in" (dim :time)]
+  (pred-nth (intersect %5 %3) (dec (:value %2)))
+
+  "nth <time> after <time>"
+  [(dim :ordinal) (dim :time) #"(?i)dopo" (dim :time)]
+  (pred-nth-after %2 %4 (dec (:value %1)))
+
+  "nth <time> after <time>"
+  [#"(?i)il|l'" (dim :ordinal) (dim :time) #"(?i)dopo" (dim :time)]
+  (pred-nth-after %3 %5 (dec (:value %2)))
 
 
   ; Years
@@ -159,7 +264,7 @@
   (year (:value %1))
 
   "year (latent)"
-  (integer -10000 999)
+  (integer -10000 -1)
   (assoc (year (:value %1)) :latent true)
 
   "year (latent)"
@@ -174,7 +279,7 @@
   ; In general we are flexible and accept both ordinals (3rd) and numbers (3)
 
   "day of month (1st)"
-  [#"(?i)(prim[oa]|1o|1º)( di)?"];
+  [#"(?i)(primo|1o|1º|1°)( di)?"];
   (day-of-month 1)
 
   "the <day-of-month>" ; this one is not latent
@@ -185,14 +290,22 @@
   [(integer 1 31) {:form :month}]
   (intersect %2 (day-of-month (:value %1)))
 
+  "<named-day> <day-of-month>" ; Friday 18
+  [{:form :day-of-week} (integer 1 31)]
+  (intersect %1 (day-of-month (:value %2)))
+
   "il <day-of-month> de <named-month>" ; il dodici luglio 2010
   [#"(?i)il" (integer 1 31) {:form :month}]
   (intersect %3 (day-of-month (:value %2)))
 
   ;; hours and minutes (absolute time)
   "<integer> (latent time-of-day)"
-  (integer 0 23)
-  (assoc (hour (:value %1) true) :latent true)
+  (integer 0 24)
+  (assoc (hour (:value %1) false) :latent true)
+
+  "le idi di <named-month>" ; the ides of march 13th for most months, but on the 15th for March, May, July, and October
+  [#"(?i)(le )?idi di" {:form :month}]
+  (intersect %2 (day-of-month (if (#{3 5 7 10} (:month %2)) 15 13)))
 
   "noon"
   #"(?i)mezz?ogiorno"
@@ -203,19 +316,42 @@
   (hour 0 false)
 
   "<time-of-day> ora"
-  [#(:full-hour %) #"(?i)or[ea]"]
-  (dissoc %1 :latent)
+  [#"(?i)or[ea]" #(:full-hour %)]
+  (dissoc %2 :latent)
 
   "at <time-of-day>" ; alle due
   [#"(?i)all[e']|le|a" {:form :time-of-day}]
   (dissoc %2 :latent)
 
 
-  "hh(:|.|h)mm (time-of-day)"
-  #"(?i)((?:[01]?\d)|(?:2[0-3]))[:h]([0-5]\d)"
+  "hh(:|h)mm (time-of-day)"
+  #"((?:[01]?\d)|(?:2[0-3]))[:h]([0-5]\d)"
   (hour-minute (Integer/parseInt (first (:groups %1)))
                (Integer/parseInt (second (:groups %1)))
-               true)
+               false)
+
+  "hh(:|h)mm (time-of-day)"
+  #"(?i)((?:0?\d)|(?:1[0-2]))[:h]([0-5]\d) d(i|el(la)?) (pomeriggio|(sta)?(sera|notte))"
+  (hour-minute (+ 12 (Integer/parseInt (first (:groups %1))))
+               (Integer/parseInt (second (:groups %1)))
+               false)
+
+  ; specific rule to address "3 in the afternoon", "9 in the evening"
+  "<integer 0 12> del <part of day>"
+  [(integer 0 12) #"(?i)d(i|el(la)?) (pomeriggio|(sta)?(sera|notte))"]
+  (hour (+ 12 (:value %1)) false)
+
+  "hh <relative-minutes> del pomeriggio(time-of-day)"
+  [(dim :time :full-hour) #(:relative-minutes %) #"(?i)d(i|el(la)?) (pomeriggio|(sta)?(sera|notte))"]
+  (if (< 12 (:full-hour %1))
+    (dissoc %1 :latent)
+    (hour-relativemin (+ 12 (:full-hour %1)) (:relative-minutes %2) false))
+
+  "hh <relative-minutes> del pomeriggio(time-of-day)"
+  [(dim :time :full-hour) #"e" #(:relative-minutes %) #"(?i)d(i|el(la)?)" #"(pomeriggio|(sta)?(sera|notte))"]
+  (if (< 12 (:full-hour %1))
+    (dissoc %1 :latent)
+    (hour-relativemin (+ 12 (:full-hour %1)) (:relative-minutes %3) false))
 
   "hhmm (military time-of-day)"
   #"(?i)((?:[01]?\d)|(?:2[0-3]))([0-5]\d)"
@@ -224,8 +360,12 @@
                 false) ; not a 12-hour clock
       (assoc :latent true))
 
+  "una"
+  #"(?i)una"
+  (hour 1 true)
+
   "quarter (relative minutes)"
-  #"(?i)quarto"
+  #"(?i)un quarto"
   {:relative-minutes 15}
 
   "trois quarts (relative minutes)"
@@ -241,7 +381,7 @@
   {:relative-minutes (:value %1)}
 
   "<integer> minutes (as relative minutes)"
-  [(integer 1 59) #"(?i)min\.?(uto)?s?"]
+  [(integer 1 59) #"(?i)min\.?(ut[oi])?"]
   {:relative-minutes (:val %1)}
 
   "<hour-of-day> <integer> (as relative minutes)"
@@ -249,7 +389,7 @@
   (hour-relativemin (:full-hour %1) (:relative-minutes %2) (:twelve-hour-clock? %1))
 
   "<hour-of-day> minus <integer> (as relative minutes)"
-  [(dim :time :full-hour) #"meno( un)?" #(:relative-minutes %)]
+  [(dim :time :full-hour) #"meno" #(:relative-minutes %)]
   (hour-relativemin (:full-hour %1) (- (:relative-minutes %3)) (:twelve-hour-clock? %1))
 
   "relative minutes to <integer> (as hour-of-day)"
@@ -257,7 +397,7 @@
   (hour-relativemin (:full-hour %3) (- (:relative-minutes %1)) true)
 
   "<hour-of-day> and <relative minutes>"
-  [(dim :time :full-hour) #"e( un)?" #(:relative-minutes %)]
+  [(dim :time :full-hour) #"e" #(:relative-minutes %)]
   (hour-relativemin (:full-hour %1) (:relative-minutes %3) (:twelve-hour-clock? %1))
 
 
@@ -277,31 +417,63 @@
 
   ; Part of day (morning, evening...). They are intervals.
   "morning"
-  #"(?i)mattin[aoe]"
+  #"(?i)mattin(ata|[aoe])"
   (assoc (interval (hour 4 false) (hour 12 false) false) :form :part-of-day :latent true)
+
+  "lunch"
+  #"(?i)(a )?pranzo"
+  (assoc (interval (hour 12 false) (hour 14 false) false) :form :part-of-day :latent true)
 
   "afternoon"
   #"(?i)pomeriggio?"
   (assoc (interval (hour 12 false) (hour 19 false) false) :form :part-of-day :latent true)
 
   "evening"
-  #"(?i)ser[ae]"
+  #"(?i)ser(ata|[ae])"
   (assoc (interval (hour 18 false) (hour 0 false) false) :form :part-of-day :latent true)
 
-  "del|di <part-of-day>" ;; removes latent
-  [#"(?i)del|di|al" {:form :part-of-day}]
-  (dissoc %2 :latent)
+  "night"
+  #"(?i)nott(e|ata)"
+  (assoc (intersect (cycle-nth :day 1) (interval (hour 0 false) (hour 4 false) false)) :form :part-of-day :latent true)
 
   "this <part-of-day>"
-  [#"(?i)questo|sta" {:form :part-of-day}]
+  [#"(?i)quest[oa]|sta|in|nel(la)?" {:form :part-of-day}]
   (assoc (intersect (cycle-nth :day 0) %2) :form :part-of-day) ;; removes :latent
+
+  "<time> notte"
+  [(dim :time) #"(?i)((in|nella|alla) )?nott(e|ata)"]
+  (intersect (cycle-nth-after :day 1 %1) (interval (hour 0 false) (hour 4 false) false))
+
+  "<time> notte"
+  [#"(?i)((nella|alla) )?nott(e|ata)( d(i|el))" (dim :time)]
+  (intersect (cycle-nth-after :day 1 %2) (interval (hour 0 false) (hour 4 false) false))
+
+  "stamattina"
+  [#"(?i)stamattina"]
+  (assoc (intersect (cycle-nth :day 0) (interval (hour 4 false) (hour 12 false) false)) :form :part-of-day)
+
+  "stasera"
+  [#"(?i)stasera"]
+  (assoc (intersect (cycle-nth :day 0) (interval (hour 18 false) (hour 0 false) false)) :form :part-of-day)
+
+  "stanotte"
+  [#"(?i)stanotte"]
+  (assoc (intersect (cycle-nth :day 1) (interval (hour 0 false) (hour 4 false) false)) :form :part-of-day)
 
   "<dim time> <part-of-day>" ; since "morning" "evening" etc. are latent, general time+time is blocked
   [(dim :time) {:form :part-of-day}]
   (intersect %1 %2)
 
-   "<part-of-day> of <dim time>" ; since "morning" "evening" etc. are latent, general time+time is blocked
-  [{:form :part-of-day} #"(?i)di" (dim :time)]
+  "<part-of-day> of <dim time>" ; since "morning" "evening" etc. are latent, general time+time is blocked
+  [{:form :part-of-day} #"(?i)d(i|el)" (dim :time)]
+  (intersect %1 %3)
+
+  "in the <part-of-day> of <dim time>" ; since "morning" "evening" etc. are latent, general time+time is blocked
+  [#"(?i)nel(la)?" {:form :part-of-day} #"(?i)d(i|el)" (dim :time)]
+  (intersect %2 %4)
+
+  "<dim time> al <part-of-day>" ; since "morning" "evening" etc. are latent, general time+time is blocked
+  [(dim :time) #"(?i)al|nel(la)?|in|d(i|el(la)?)" {:form :part-of-day}]
   (intersect %1 %3)
 
   ;specific rule to address "3 in the morning","3h du matin" and extend morning span from 0 to 12
@@ -311,10 +483,26 @@
 
   ; Other intervals: week-end, seasons
   "week-end"
-  #"(?i)week[ -]?end"
+  #"(?i)week[ -]?end|fine ?settimana|we"
   (interval (intersect (day-of-week 5) (hour 18 false))
             (intersect (day-of-week 1) (hour 0 false))
             false)
+
+  "season"
+  #"(?i)(in )?estate" ;could be smarter and take the exact hour into account... also some years the day can change
+  (interval (month-day 6 21) (month-day 9 23) false)
+
+  "season"
+  #"(?i)(in )?autunno"
+  (interval (month-day 9 23) (month-day 12 21) false)
+
+  "season"
+  #"(?i)(in )?inverno"
+  (interval (month-day 12 21) (month-day 3 20) false)
+
+  "season"
+  #"(?i)(in )?primavera"
+  (interval (month-day 3 20) (month-day 6 21) false)
 
   ; Absorptions
 
@@ -335,6 +523,89 @@
   [(dim :time) (dim :timezone)]
   (assoc %1 :timezone (:value %2))
 
+  ; Precision
+  ; FIXME
+  ; - should be applied to all dims not just time-of-day
+  ;-  shouldn't remove latency, except maybe -ish
+
+  "<time-of-day> circa" ; 7ish
+  [{:form :time-of-day} #"(?i)circa"]
+  (-> %1
+    (dissoc :latent)
+    (merge {:precision "approximate"}))
+
+  "<time-of-day> precise" ; sharp
+  [{:form :time-of-day} #"(?i)precise"]
+  (-> %1
+    (dissoc :latent)
+    (merge {:precision "exact"}))
+
+  "circa per le <time-of-day>" ; about
+  [#"(?i)(circa )?per( le)?|circa( alle)?|verso( le)?" {:form :time-of-day}]
+  (-> %2
+    (dissoc :latent)
+    (merge {:precision "approximate"}))
+
+
   ; Intervals
+
+  "dd-dd <month> (interval)"
+  [#"(?i)(?:dal(?:(?:le)? |l'))?(3[01]|[12]\d|0?[1-9])" #"(?i)\-|([fs]ino )?al(l')?" #"(3[01]|[12]\d|0?[1-9])" {:form :month}]
+  (interval (intersect %4 (day-of-month (Integer/parseInt (-> %1 :groups first))))
+            (intersect %4 (day-of-month (Integer/parseInt (-> %3 :groups first))))
+            true)
+
+  "dd-dd <month> (interval)"
+  [#"(?i)tra( il|l')?" #"(3[01]|[12]\d|0?[1-9])" #"(?i)e( il|l')?" #"(3[01]|[12]\d|0?[1-9])" {:form :month}]
+  (interval (intersect %5 (day-of-month (Integer/parseInt (-> %2 :groups first))))
+            (intersect %5 (day-of-month (Integer/parseInt (-> %4 :groups first))))
+            true)
+
+  ; Blocked for :latent time. May need to accept certain latents only, like hours
+
+  "<datetime> - <datetime> (interval)"
+  [(dim :time #(not (:latent %))) #"\-|[fs]ino a(l(l[e'])?)?" (dim :time #(not (:latent %)))]
+  (interval %1 %3 true)
+
+  "fino al <datetime> (interval)"
+  [#"\-|[fs]ino a(l(l[ae'])?)?" (dim :time #(not (:latent %)))]
+  (interval (cycle-nth :second 0) %2 false)
+
+  "dal <datetime> al <datetime> (interval)"
+  [#"(?i)da(l(l')?)?" (dim :time) #"\-|([fs]ino )?al(l')?" (dim :time)]
+  (interval %2 %4 true)
+
+  "tra il <datetime> e il <datetime> (interval)"
+  [#"(?i)tra( il| l')?" (dim :time) #"e( il| l')?" (dim :time)]
+  (interval %2 %4 true)
+
+  "<time-of-day> - <time-of-day> <day-of-month> (interval)"
+  [{:form :time-of-day} #"\-" {:form :time-of-day} (dim :time #(not (:latent %)))]
+  (interval (intersect %1 %4) (intersect %3 %4) true)
+
+  ; Specific for time-of-day, to help resolve ambiguities
+
+  "dalle <time-of-day> alle <time-of-day> (interval)"
+  [#"(?i)da(l(le|l')?)?" {:form :time-of-day} #"\-|([fs]ino )?a(l(l[e'])?)?" {:form :time-of-day}]
+  (interval %2 %4 true)
+
+  ; Specific for within duration... Would need to be reworked
+  "in <duration>"
+  [#"(?i)in|per|entro" (dim :duration)]
+  (interval (cycle-nth :second 0) (in-duration (:value %2)) false)
+
+  "entro il <duration>"
+  [#"(?i)entro (il|l')|per (il|l[a'])|in|nel(l[a'])?" (dim :unit-of-duration)]
+  (interval (cycle-nth :second 0) (cycle-nth (:grain %2) 1) false)
+
+  ; One-sided Intervals
+
+  "entro le <time-of-day>"
+  [#"(?i)entro( l[ea'])?|prima d(i|ell['e])" (dim :time)]
+  (merge %2 {:direction :before})
+
+  "dopo le <time-of-day>"
+  [#"(?i)dopo( l[e'])?|dall['e]" (dim :time)]
+  (merge %2 {:direction :after})
 
 )


### PR DESCRIPTION
I'm here with my pull request as I announced in the Facebook thread ;-)

Italian now supports intervals, holidays, precision, seasons; clock is set to 24 hours and allows using “di pomeriggio”; many fixes.