### PR TITLE
Expressions like "ein Hotel" or "ein Angebot" in German are not 1h

### DIFF
--- a/resources/languages/de/rules/time.clj
+++ b/resources/languages/de/rules/time.clj
@@ -257,7 +257,7 @@
   [#"(?i)der|das" (dim :ordinal) (dim :time) #"(?i)nach" (dim :time)];Check me
   (pred-nth-after %3 %5 (dec (:value %2)))
 
-    ; Years
+  ; Years
   ; Between 1000 and 2100 we assume it's a year
   ; Outside of this, it's safer to consider it's latent
 
@@ -334,7 +334,7 @@
   (assoc (hour (:value %1) (< (:value %1) 12)) :latent true)
 
   "<time-of-day>  o'clock"
-  [#(:full-hour %) #"(?i)uhr|h"]
+  [#(:full-hour %) #"(?:(?i)uhr|h)(?:\s|$)"]
   (dissoc %1 :latent)
 
   "at <time-of-day>" ; absorption
@@ -371,7 +371,7 @@
         (assoc :form :time-of-day)))
 
   "<time-of-day> am|pm"
-  [{:form :time-of-day} #"(?i)([ap])(\s|\.)?m?\.?"];Check me DO WE NEED THIS
+  [{:form :time-of-day} #"(?i)([ap])\.?m\.?(?:\s|$)"];Check me DO WE NEED THIS
   ;; TODO set_am fn in helpers => add :ampm field
   (let [[p meridiem] (if (= "a" (-> %2 :groups first clojure.string/lower-case))
                        [[(hour 0) (hour 12) false] :am]

--- a/resources/languages/de/rules/time.clj
+++ b/resources/languages/de/rules/time.clj
@@ -25,7 +25,6 @@
   [#"(?i)an einem" {:form :day-of-week}]
   %2 ; does NOT dissoc latent
 
-
   ;;;;;;;;;;;;;;;;;;;
   ;; Named things
 
@@ -334,7 +333,7 @@
   (assoc (hour (:value %1) (< (:value %1) 12)) :latent true)
 
   "<time-of-day>  o'clock"
-  [#(:full-hour %) #"(?:(?i)uhr|h)(?:\s|$)"]
+  [#(:full-hour %) #"(?:(?i)uhr|h)(?:\p{P}|\p{Z}|$)"]
   (dissoc %1 :latent)
 
   "at <time-of-day>" ; absorption
@@ -355,7 +354,7 @@
       (assoc :latent true))
 
   "hhmm (military) am|pm" ; hh only from 00 to 12
-  [#"(?i)((?:1[012]|0?\d))([0-5]\d)" #"(?i)([ap])\.?m?\.?"]
+  [#"(?i)((?:1[012]|0?\d))([0-5]\d)" #"(?i)([ap])\.?m\.?(?:\p{P}|\p{Z}|$)"]
   ; (-> (hour-minute (Integer/parseInt (first (:groups %1)))
   ;                  (Integer/parseInt (second (:groups %1)))
   ;                  false) ; not a 12-hour clock)
@@ -371,7 +370,7 @@
         (assoc :form :time-of-day)))
 
   "<time-of-day> am|pm"
-  [{:form :time-of-day} #"(?i)([ap])\.?m\.?(?:\s|$)"];Check me DO WE NEED THIS
+  [{:form :time-of-day} #"(?i)([ap])\.?m\.?(?:\p{P}|\p{Z}|$)"];Check me DO WE NEED THIS
   ;; TODO set_am fn in helpers => add :ampm field
   (let [[p meridiem] (if (= "a" (-> %2 :groups first clojure.string/lower-case))
                        [[(hour 0) (hour 12) false] :am]


### PR DESCRIPTION
Fixed this by adding some minimal requirement on the context, i.e. that there
is a space after the "H" or "A" or that this appears at the end of the
text.

Actually the rule for "am|pm" is pretty useless for German, at least "am|pm" is at
most a corner case.