### PR TITLE
Add support for emails with hyphens and underscores in ES

### DIFF
--- a/resources/languages/es/corpus/communication.clj
+++ b/resources/languages/es/corpus/communication.clj
@@ -22,6 +22,8 @@
  
  "alex@wit.ai"
  "alex.lebrun@mail.wit.com"
+ "alex-lebrun@mail.wit.com"
+ "alex_lebrun@mail.wit.com"
  (fn [token _] (and (= :email (:dim token))
                     (= (:text token) (:val token))))
  

--- a/resources/languages/es/rules/communication.clj
+++ b/resources/languages/es/rules/communication.clj
@@ -27,7 +27,7 @@
   :value (-> %1 :groups first)}
 
  "email"
- #"([\w\.]+@[\w\.]+)"
+ #"([\w\.\-_]+@[\w\.\-_]+)"
  {:dim :email
   :value (-> %1 :groups first)}
  


### PR DESCRIPTION
Hi, this pull request modifies Spanish email regex to detect mails with hyphens and underscores as well as in English.

If anything is wrong please tell me and I will fix it as soon as possible to get this merged. I tried to follow all the steps from

Thanks!