### PR TITLE
Fix DuplicateFormatFlagsException when max-iter-reached exceeded

### DIFF
--- a/src/duckling/engine.clj
+++ b/src/duckling/engine.clj
@@ -204,9 +204,9 @@
       (if (or max-iter-reached? max-stash-reached? finished?)
         (do
           (when max-iter-reached?
-            (warnf (format "@pass-all reached maximum iterations for sentence '%s'" sentence)))
+            (warnf "@pass-all reached maximum iterations for sentence '%s'" sentence))
           (when max-stash-reached?
-            (warnf (format "@pass-all reached maximum stash size for sentence '%s'" sentence)))
+            (warnf "@pass-all reached maximum stash size for sentence '%s'" sentence))
           stash)
         (recur (pass-once stash rules sentence) (count stash) (dec remaining-iter))))))
 


### PR DESCRIPTION
The warning message was formatted, and then this string was used as a format for warnf.  This fails for certain sentences.

```
DuplicateFormatFlagsException Flags = '-'  java.util.Formatter$Flags.parse (Formatter.java:4186)
```